### PR TITLE
Print warning when disabling SIO_UDP_CONNRESET fails.

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -426,6 +426,7 @@ struct netcode_socket_holder_t
 #define NETCODE_SOCKET_ERROR_BIND_IPV6_FAILED                   7
 #define NETCODE_SOCKET_ERROR_GET_SOCKNAME_IPV4_FAILED           8
 #define NETCODE_SOCKET_ERROR_GET_SOCKNAME_IPV6_FAILED           7
+#define NETCODE_SOCKET_ERROR_DISABLE_UDP_PORT_CONNRESET_FAILED  10
 
 void netcode_socket_destroy( struct netcode_socket_t * socket )
 {
@@ -478,7 +479,9 @@ int netcode_socket_create( struct netcode_socket_t * s, struct netcode_address_t
     DWORD dwBytesReturned = 0;
     if ( WSAIoctl( s->handle, SIO_UDP_CONNRESET, &bNewBehavior, sizeof(bNewBehavior), NULL, 0, &dwBytesReturned, NULL, NULL ) != 0 )
     {
-        netcode_printf( NETCODE_LOG_LEVEL_ERROR, "warning: failed to disable UDP port unreachable messages on socket\n" );
+        netcode_printf( NETCODE_LOG_LEVEL_ERROR, "error: failed to disable UDP CONNRESET (port unreachable) message reporting on socket\n" );
+        netcode_socket_destroy( s );
+        return NETCODE_SOCKET_ERROR_DISABLE_UDP_PORT_CONNRESET_FAILED;
     }
 #endif
 

--- a/netcode.c
+++ b/netcode.c
@@ -476,7 +476,10 @@ int netcode_socket_create( struct netcode_socket_t * s, struct netcode_address_t
     #define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
     BOOL bNewBehavior = FALSE;
     DWORD dwBytesReturned = 0;
-    WSAIoctl( s->handle, SIO_UDP_CONNRESET, &bNewBehavior, sizeof(bNewBehavior), NULL, 0, &dwBytesReturned, NULL, NULL );
+    if ( WSAIoctl( s->handle, SIO_UDP_CONNRESET, &bNewBehavior, sizeof(bNewBehavior), NULL, 0, &dwBytesReturned, NULL, NULL ) != 0 )
+    {
+        netcode_printf( NETCODE_LOG_LEVEL_ERROR, "warning: failed to disable UDP port unreachable messages on socket\n" );
+    }
 #endif
 
     // force IPv6 only if necessary


### PR DESCRIPTION
It's tagged as "IMPORTANT" in the comment, so perhaps add a message when it fails? I don't think this particular setting failing to be set warrants destroying the socket, though, so I opted not to do that.