### PR TITLE
QOS_FLOWID and QOS_NON_ADAPTIVE_FLOW are not defined correctly by MinGW

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -469,6 +469,13 @@ void netcode_socket_destroy( struct netcode_socket_t * socket )
 #include <ws2ipdef.h>
 #include <wininet.h>
 #include <iphlpapi.h>
+
+#ifdef __MINGW32__
+typedef UINT32 QOS_FLOWID, *PQOS_FLOWID;
+#ifndef QOS_NON_ADAPTIVE_FLOW
+#define QOS_NON_ADAPTIVE_FLOW 0x00000002
+#endif // #ifndef QOS_NON_ADAPTIVE_FLOW
+#endif // #ifdef __MINGW32__
 #include <qos2.h>
 
 #pragma comment( lib, "Qwave.lib" )
@@ -2550,7 +2557,7 @@ void netcode_default_client_config( struct netcode_client_config_t * config )
     config->override_send_and_receive = 0;
     config->send_packet_override = NULL;
     config->receive_packet_override = NULL;
-};
+}
 
 struct netcode_client_t
 {
@@ -3753,7 +3760,7 @@ void netcode_default_server_config( struct netcode_server_config_t * config )
     config->override_send_and_receive = 0;
     config->send_packet_override = NULL;
     config->receive_packet_override = NULL;
-};
+}
 
 struct netcode_server_t
 {


### PR DESCRIPTION
I found the following when I rebased the changes discussed [here](https://github.com/mas-bandwidth/yojimbo/issues/203) and rebuilt with MSYS2.
