### PR TITLE
Disable packet tagging on MingW by default, fix TLS qualifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         msystem: UCRT64
         update: true
         install: >-
+          mingw-w64-ucrt-x86_64-make
           mingw-w64-ucrt-x86_64-premake
           mingw-w64-ucrt-x86_64-gcc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
     - uses: actions/checkout@master
 
@@ -69,18 +73,17 @@ jobs:
     - name: Setup (msys2)
       uses: msys2/setup-msys2@v2
       with:
+        msystem: UCRT64
         update: true
         install: >-
-          mingw-w64-premake
-          mingw-w64-gcc
+          premake
+          mingw-w64-ucrt-x86_64-gcc
 
     - name: Build (msys2)
-      shell: msys2 {0}
       run: |
         premake5 gmake
         make clean
         make all config=${{ matrix.configuration }}
 
     - name: Test (msys2)
-      shell: msys2 {0}
-      run: "& ./bin/test.exe"
+      run: "./bin/test.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,12 @@ jobs:
       uses: msys2/setup-msys2@v2
 
     - name: Build (msys2)
+      shell: msys2 {0}
       run: |
         premake5 gmake
         make clean
         make all config=${{ matrix.configuration }}
 
     - name: Test (msys2)
+      shell: msys2 {0}
       run: "& ./bin/test.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Setup premake
-      uses: abel0b/setup-premake@v1
 
     # Set up msys2/MingW-w64 toolchain
     - name: Setup (msys2)
       uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: >-
+          mingw-w64-premake
+          mingw-w64-gcc
 
     - name: Build (msys2)
       shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,31 @@ jobs:
     - name: Test (vs2019)
       if: runner.os == 'Windows'
       run: "& ./bin/test.exe"
-    
+
+  build_and_test_mingw:
+    name: Build & test
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+        configuration: [release, debug]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup premake
+      uses: abel0b/setup-premake@v1
+
+    steps:
+    # Set up msys2/MingW-w64 toolchain
+    - name: Setup (msys2)
+      uses: msys2/setup-msys2@v2
+
+    - name: Build (msys2)
+      run: |
+        premake5 gmake
+        make config=${{ matrix.configuration }}
+
+    - name: Test (msys2)
+      run: "& ./bin/test.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
     - name: Build (msys2)
       run: |
         premake5 gmake
-        make clean
-        make all config=${{ matrix.configuration }}
+        mingw-w64-ucrt-x86_64-make clean
+        mingw-w64-ucrt-x86_64-make all config=${{ matrix.configuration }}
 
     - name: Test (msys2)
       run: "./bin/test.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       run: "& ./bin/test.exe"
 
   build_and_test_mingw:
-    name: Build & test
+    name: Build & test (MingW)
 
     strategy:
       matrix:
@@ -74,7 +74,8 @@ jobs:
     - name: Build (msys2)
       run: |
         premake5 gmake
-        make config=${{ matrix.configuration }}
+        make clean
+        make all config=${{ matrix.configuration }}
 
     - name: Test (msys2)
       run: "& ./bin/test.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
     - name: Build (msys2)
       run: |
         premake5 gmake
-        mingw-w64-ucrt-x86_64-make clean
-        mingw-w64-ucrt-x86_64-make all config=${{ matrix.configuration }}
+        mingw32-make clean
+        mingw32-make all config=${{ matrix.configuration }}
 
     - name: Test (msys2)
       run: "./bin/test.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
     - name: Setup premake
       uses: abel0b/setup-premake@v1
 
-    steps:
     # Set up msys2/MingW-w64 toolchain
     - name: Setup (msys2)
       uses: msys2/setup-msys2@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         msystem: UCRT64
         update: true
         install: >-
-          premake
+          mingw-w64-ucrt-x86_64-premake
           mingw-w64-ucrt-x86_64-gcc
 
     - name: Build (msys2)

--- a/netcode.c
+++ b/netcode.c
@@ -82,6 +82,10 @@ void netcode_enable_packet_tagging()
     netcode_packet_tagging_enabled = 1;
 }
 
+#else
+
+void netcode_enable_packet_tagging() {}
+
 #endif // #if NETCODE_PACKET_TAGGING
 
 // ------------------------------------------------------------------

--- a/netcode.c
+++ b/netcode.c
@@ -168,15 +168,19 @@ void netcode_default_free_function( void * context, void * pointer )
     #include <ws2tcpip.h>
     #include <ws2ipdef.h>
     #include <iphlpapi.h>
+    #ifdef _MSC_VER
     #pragma comment( lib, "WS2_32.lib" )
     #pragma comment( lib, "IPHLPAPI.lib" )
+    #endif // #ifdef _MSC_VER
 
     #ifdef SetPort
     #undef SetPort
     #endif // #ifdef SetPort
 
     #include <iphlpapi.h>
+    #ifdef _MSC_VER
     #pragma comment( lib, "IPHLPAPI.lib" )
+    #endif // #ifdef _MSC_VER
     
 #elif NETCODE_PLATFORM == NETCODE_PLATFORM_MAC || NETCODE_PLATFORM == NETCODE_PLATFORM_UNIX
 
@@ -482,7 +486,9 @@ typedef UINT32 QOS_FLOWID, *PQOS_FLOWID;
 #endif // #ifdef __MINGW32__
 #include <qos2.h>
 
+#ifdef _MSC_VER
 #pragma comment( lib, "Qwave.lib" )
+#endif // #ifdef _MSC_VER
 
 static int netcode_set_socket_codepoint( SOCKET socket, QOS_TRAFFIC_TYPE trafficType, QOS_FLOWID flowId, PSOCKADDR addr ) 
 {

--- a/netcode.c
+++ b/netcode.c
@@ -161,7 +161,9 @@ void netcode_default_free_function( void * context, void * pointer )
 
 #if NETCODE_PLATFORM == NETCODE_PLATFORM_WINDOWS
 
+    #ifndef NOMINMAX
     #define NOMINMAX
+    #endif // #ifndef NOMINMAX
     #define _WINSOCK_DEPRECATED_NO_WARNINGS
     #include <winsock2.h>
     #include <ws2def.h>
@@ -5227,7 +5229,9 @@ double netcode_time()
 
 // windows
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif // #ifndef NOMINMAX
 #include <windows.h>
 
 void netcode_sleep( double time )

--- a/netcode.h
+++ b/netcode.h
@@ -113,12 +113,16 @@ int netcode_init();
 void netcode_term();
 
 #ifndef NETCODE_PACKET_TAGGING
+#ifndef __MINGW32__
 #define NETCODE_PACKET_TAGGING 1
+#else
+// At least as of version 14.2.0, the Qwave library is not properly implemented
+// in MingW-w64, so packet tagging is disabled by default.
+#define NETCODE_PACKET_TAGGING 0
+#endif // #ifndef __MINGW32__
 #endif // #ifndef NETCODE_PACKET_TAGGING
 
-#if NETCODE_PACKET_TAGGING
 void netcode_enable_packet_tagging();
-#endif // #if NETCODE_PACKET_TAGGING
 
 struct netcode_address_t
 {

--- a/premake5.lua
+++ b/premake5.lua
@@ -31,6 +31,9 @@ project "sodium"
         }
     filter { "action:gmake*" }
         buildoptions { "-Wno-unused-parameter", "-Wno-unused-function", "-Wno-unknown-pragmas", "-Wno-unused-variable", "-Wno-type-limits" }
+        if os.target() == "windows" then
+            links { "ws2_32", "iphlpapi" }
+        end
 
 project "test"
     files { "test.cpp" }

--- a/premake5.lua
+++ b/premake5.lua
@@ -31,33 +31,42 @@ project "sodium"
         }
     filter { "action:gmake*" }
         buildoptions { "-Wno-unused-parameter", "-Wno-unused-function", "-Wno-unknown-pragmas", "-Wno-unused-variable", "-Wno-type-limits" }
-        if os.target() == "windows" then
-            links { "ws2_32", "iphlpapi" }
-        end
 
 project "test"
     files { "test.cpp" }
     links { "sodium" }
+    filter { "action:gmake*", "system:windows" }
+        links { "ws2_32", "iphlpapi" }
 
 project "soak"
     files { "soak.c", "netcode.c" }
     links { "sodium" }
+    filter { "action:gmake*", "system:windows" }
+        links { "ws2_32", "iphlpapi" }
 
 project "profile"
     files { "profile.c", "netcode.c" }    
     links { "sodium" }
+    filter { "action:gmake*", "system:windows" }
+        links { "ws2_32", "iphlpapi" }
 
 project "client"
     files { "client.c", "netcode.c" }
     links { "sodium" }
+    filter { "action:gmake*", "system:windows" }
+        links { "ws2_32", "iphlpapi" }
 
 project "server"
     files { "server.c", "netcode.c" }
     links { "sodium" }
+    filter { "action:gmake*", "system:windows" }
+        links { "ws2_32", "iphlpapi" }
 
 project "client_server"
     files { "client_server.c", "netcode.c" }
     links { "sodium" }
+    filter { "action:gmake*", "system:windows" }
+        links { "ws2_32", "iphlpapi" }
 
 newaction
 {

--- a/sodium/sodium_randombytes_salsa20_random.c
+++ b/sodium/sodium_randombytes_salsa20_random.c
@@ -89,6 +89,10 @@ BOOLEAN NTAPI RtlGenRandom(PVOID RandomBuffer, ULONG RandomBufferLength);
 # endif
 #endif
 
+#if !defined(TLS) && !defined(__STDC_NO_THREADS__) && \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+# define TLS _Thread_local
+#endif
 #ifndef TLS
 # ifdef _WIN32
 #  define TLS __declspec(thread)


### PR DESCRIPTION
Added back netcode_enable_packet_tagging() even when NETCODE_PACKET_TAGGING=0 because otherwise code calling it (Yojimbo) would not compile.