### PR TITLE
Extend detection of little-endianness

### DIFF
--- a/netcode.h
+++ b/netcode.h
@@ -38,7 +38,8 @@
 #error Can only define one of debug & release
 #endif
 
-#if    defined(__386__) || defined(i386)    || defined(__i386__)  \
+#if __LITTLE_ENDIAN__ \
+    || defined(__386__) || defined(i386)    || defined(__i386__)  \
     || defined(__X86)   || defined(_M_IX86)                       \
     || defined(_M_X64)  || defined(__x86_64__)                    \
     || defined(alpha)   || defined(__alpha) || defined(__alpha__) \


### PR DESCRIPTION
I attempted a build on the `ppc64le` architecture and the the tests failed because the macro machinery evaluated that it was a big endian architecture.
For your information, these the some interesting macros defined on that architecture:
```
<mock-chroot> sh-5.3# gcc -dM -E -mcpu=powerpc64le - < /dev/null | grep --ignore-case 'ppc'
#define _ARCH_PPCGR 1
#define __PPC64__ 1
#define _ARCH_PPCSQ 1
#define __PPC__ 1
#define _ARCH_PPC 1
#define _ARCH_PPC64 1

<mock-chroot> sh-5.3# gcc -dM -E -mcpu=powerpc64le - < /dev/null | grep --ignore-case 'endian'
#define __ORDER_LITTLE_ENDIAN__ 1234
#define _LITTLE_ENDIAN 1
#define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
#define __ORDER_PDP_ENDIAN__ 3412
#define __LITTLE_ENDIAN__ 1
#define __ORDER_BIG_ENDIAN__ 4321
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
#define __VEC_ELEMENT_REG_ORDER__ __ORDER_LITTLE_ENDIAN__
```