### PR TITLE
Fix disconnects caused by unintialized variables.

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -799,7 +799,7 @@ int netcode_socket_receive_packet( struct netcode_socket_t * socket, struct netc
     typedef int socklen_t;
 #endif // #if NETCODE_PLATFORM == NETCODE_PLATFORM_WINDOWS
     
-    struct sockaddr_storage sockaddr_from;
+    struct sockaddr_storage sockaddr_from = {0};
     socklen_t from_length = sizeof( sockaddr_from );
 
     int result = recvfrom( socket->handle, (char*) packet_data, max_packet_size, 0, (struct sockaddr*) &sockaddr_from, &from_length );
@@ -4676,7 +4676,7 @@ void netcode_server_receive_packets( struct netcode_server_t * server )
 
         while ( 1 )
         {
-            struct netcode_address_t from;
+            struct netcode_address_t from = {0};
             
             uint8_t packet_data[NETCODE_MAX_PACKET_BYTES];
             

--- a/netcode.c
+++ b/netcode.c
@@ -800,7 +800,7 @@ int netcode_socket_receive_packet( struct netcode_socket_t * socket, struct netc
 #endif // #if NETCODE_PLATFORM == NETCODE_PLATFORM_WINDOWS
     
     struct sockaddr_storage sockaddr_from;
-    memset(&sockaddr_from, 0, sizeof(sockaddr_from));
+    memset( &sockaddr_from, 0, sizeof(sockaddr_from) );
 
     socklen_t from_length = sizeof( sockaddr_from );
 
@@ -4679,7 +4679,7 @@ void netcode_server_receive_packets( struct netcode_server_t * server )
         while ( 1 )
         {
             struct netcode_address_t from;
-            memset(&from, 0, sizeof(from));
+            memset( &from, 0, sizeof(from) );
 
             uint8_t packet_data[NETCODE_MAX_PACKET_BYTES];
             

--- a/netcode.c
+++ b/netcode.c
@@ -799,7 +799,9 @@ int netcode_socket_receive_packet( struct netcode_socket_t * socket, struct netc
     typedef int socklen_t;
 #endif // #if NETCODE_PLATFORM == NETCODE_PLATFORM_WINDOWS
     
-    struct sockaddr_storage sockaddr_from = {0};
+    struct sockaddr_storage sockaddr_from;
+    memset(&sockaddr_from, 0, sizeof(sockaddr_from));
+
     socklen_t from_length = sizeof( sockaddr_from );
 
     int result = recvfrom( socket->handle, (char*) packet_data, max_packet_size, 0, (struct sockaddr*) &sockaddr_from, &from_length );
@@ -4676,8 +4678,9 @@ void netcode_server_receive_packets( struct netcode_server_t * server )
 
         while ( 1 )
         {
-            struct netcode_address_t from = {0};
-            
+            struct netcode_address_t from;
+            memset(&from, 0, sizeof(from));
+
             uint8_t packet_data[NETCODE_MAX_PACKET_BYTES];
             
             int packet_bytes = 0;


### PR DESCRIPTION
In case of IPv4, IPv6 part was uninitialized and stack content changed in some cases which in turn prevented hash map lookup and subsequently loosing all packets, up to disconnect.