### PR TITLE
Fix IPv6 address parsing, Linux packet tagging, dual stack server connects, and other bugs

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -3792,6 +3792,7 @@ struct netcode_server_t
     struct netcode_server_config_t config;
     struct netcode_socket_holder_t socket_holder;
     struct netcode_address_t address;
+    struct netcode_address_t address2;
     uint32_t flags;
     double time;
     int running;
@@ -3924,6 +3925,7 @@ struct netcode_server_t * netcode_server_create_dual( NETCODE_CONST char * serve
     server->socket_holder.ipv4 = socket_ipv4;
     server->socket_holder.ipv6 = socket_ipv6;
     server->address = server_address1;
+    server->address2 = server_address2;
     server->time = time;
     server->global_sequence = 1ULL << 63;
 
@@ -4254,6 +4256,10 @@ void netcode_server_process_connection_request_packet( struct netcode_server_t *
     for ( i = 0; i < connect_token_private.num_server_addresses; i++ )
     {
         if ( netcode_address_equal( &server->address, &connect_token_private.server_addresses[i] ) )
+        {
+            found_server_address = 1;
+        }
+        if ( server->address2.type != NETCODE_ADDRESS_NONE && netcode_address_equal( &server->address2, &connect_token_private.server_addresses[i] ) )
         {
             found_server_address = 1;
         }
@@ -6792,7 +6798,7 @@ void test_client_server_connect()
     netcode_network_simulator_destroy( network_simulator );
 }
 
-void client_server_socket_connect( NETCODE_CONST char * client_address, NETCODE_CONST char * client_address2, NETCODE_CONST char * server_address, NETCODE_CONST char * server_address2 )
+void client_server_socket_connect_to( NETCODE_CONST char * client_address, NETCODE_CONST char * client_address2, NETCODE_CONST char * server_address, NETCODE_CONST char * server_address2, NETCODE_CONST char * connect_address )
 {
     double time = 0.0;
     double delta_time = 1.0 / 10.0;
@@ -6823,7 +6829,7 @@ void client_server_socket_connect( NETCODE_CONST char * client_address, NETCODE_
 
     uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
 
-    check( netcode_generate_connect_token( 1, &server_address, &server_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, private_key, user_data, connect_token ) );
+    check( netcode_generate_connect_token( 1, &connect_address, &connect_address, TEST_CONNECT_TOKEN_EXPIRY, TEST_TIMEOUT_SECONDS, client_id, TEST_PROTOCOL_ID, private_key, user_data, connect_token ) );
 
     netcode_client_connect( client, connect_token );
 
@@ -6848,6 +6854,11 @@ void client_server_socket_connect( NETCODE_CONST char * client_address, NETCODE_
     netcode_server_destroy( server );
 
     netcode_client_destroy( client );
+}
+
+void client_server_socket_connect( NETCODE_CONST char * client_address, NETCODE_CONST char * client_address2, NETCODE_CONST char * server_address, NETCODE_CONST char * server_address2 )
+{
+    client_server_socket_connect_to( client_address, client_address2, server_address, server_address2, server_address );
 }
 
 void test_client_server_ipv4_socket_connect()
@@ -6875,6 +6886,12 @@ void test_client_server_dual_socket_connect()
     // dual stack client connects to dual stack server over ipv6
 
     client_server_socket_connect("0.0.0.0:50000", "[::]:50000", "[::1]:40000", "127.0.0.1:40000");
+
+    // dual stack client connects to the second address of a dual stack server (ipv6, then ipv4)
+
+    client_server_socket_connect_to("0.0.0.0:50000", "[::]:50000", "127.0.0.1:40000", "[::1]:40000", "[::1]:40000");
+
+    client_server_socket_connect_to("0.0.0.0:50000", "[::]:50000", "[::1]:40000", "127.0.0.1:40000", "127.0.0.1:40000");
 }
 
 void test_client_server_keep_alive()

--- a/profile.c
+++ b/profile.c
@@ -161,7 +161,7 @@ void profile_iteration( double time )
                 {
                     if ( netcode_server_client_connected( server[i], client_index ) )
                     {
-                        netcode_server_send_packet( server[i], 0, packet_data, NETCODE_MAX_PACKET_SIZE );
+                        netcode_server_send_packet( server[i], client_index, packet_data, NETCODE_MAX_PACKET_SIZE );
                     }
                 }
 

--- a/server.c
+++ b/server.c
@@ -63,15 +63,24 @@ int main( int argc, char ** argv )
     #define TEST_PROTOCOL_ID 0x1122334455667788
 
     char * server_address = "127.0.0.1:40000";
+    char * server_address2 = "[::1]:40000";
     if ( argc == 2 )
+    {
         server_address = argv[1];
+        server_address2 = NULL;
+    }
+    else if ( argc == 3 )
+    {
+        server_address = argv[1];
+        server_address2 = argv[2];
+    }
 
     struct netcode_server_config_t server_config;
     netcode_default_server_config( &server_config );
     server_config.protocol_id = TEST_PROTOCOL_ID;
     memcpy( &server_config.private_key, private_key, NETCODE_KEY_BYTES );
 
-    struct netcode_server_t * server = netcode_server_create( server_address, &server_config, time );
+    struct netcode_server_t * server = netcode_server_create_dual( server_address, server_address2, &server_config, time );
 
     if ( !server )
     {

--- a/soak.c
+++ b/soak.c
@@ -196,7 +196,7 @@ void soak_iteration( double time )
                 {
                     if ( netcode_server_client_connected( server[i], client_index ) )
                     {
-                        netcode_server_send_packet( server[i], 0, packet_data, random_int( 1, NETCODE_MAX_PACKET_SIZE ) );
+                        netcode_server_send_packet( server[i], client_index, packet_data, random_int( 1, NETCODE_MAX_PACKET_SIZE ) );
                     }
                 }
 


### PR DESCRIPTION
## What changed

Bug fixes from a full review of netcode.c, plus dual stack improvements and new test coverage.

### Bug fixes

- **`netcode_parse_address`: bracketed IPv6 addresses with short ports failed or corrupted.** `[::1]:5` returned an error and `[fe80::1]:5` was corrupted mid-parse — the port scan didn't stop after finding the port colon, kept scanning into the address, and could clobber the port and truncate the string. The scan now breaks on the port colon and requires it to be preceded by `]`. Bracketed addresses without a port (`[::1]`, `[fe80::1]`) now parse with port 0, consistent with unbracketed forms (if a port is omitted, it is assumed to be zero).
- **Dual stack servers rejected connects to their second address.** The connect token whitelist check only compared against the server's first public address, so a client connecting to the second address got "server address not in connect token whitelist". The server now stores its second address and accepts connect tokens naming either one.
- **Packet tagging was dead code on Linux.** The block was guarded by `NETCODE_PLATFORM_LINUX`, which is never defined anywhere (undefined macros evaluate to 0 in the preprocessor), so `netcode_enable_packet_tagging()` silently did nothing on Linux. It also referenced `socket->handle` where the parameter is named `s`, which would not have compiled had the guard matched. Now guarded by `NETCODE_PLATFORM_UNIX` with the correct handle.
- **Failed `socket()` calls were undetected on Mac/Unix.** The handle is an unsigned `size_t`, so the -1 error return wraps and `<= 0` never matched; failure was only caught indirectly by the next `setsockopt` with a misleading error. Now checks for `(netcode_socket_handle_t) -1`.
- **Release-build stack overflow on API misuse.** `netcode_client_send_packet` / `netcode_server_send_packet` enforced `packet_bytes <= NETCODE_MAX_PACKET_SIZE` only via `netcode_assert`, which compiles out under `NDEBUG`. Out-of-range sizes are now dropped at runtime.
- **Network simulator leak.** The duplicate-packet path overwrote a queue entry without freeing it. The free-before-overwrite moved into `netcode_network_simulator_queue_packet`, covering both paths.

### API

- Renamed `netcode_client_create_overload` / `netcode_server_create_overload` to `netcode_client_create_dual` / `netcode_server_create_dual` (they create dual sockets), and declared both in netcode.h — previously they were defined but never exported, so external callers couldn't use them.
- client.c example binds both IPv4 and IPv6 via `netcode_client_create_dual( "0.0.0.0", "::", ... )` so it works with an IPv6 server address on the command line.
- server.c example runs dual stack by default (`127.0.0.1:40000` + `[::1]:40000`), overridable with one or two command line arguments.

### Tests

- New parse tests: `[::1]:5`, `[fe80::1]:5` (the previously-broken short-port forms), `::0`, `[::1]`, `[::0]`, `[fe80::1]` (no-port forms, locked in as port 0).
- New `test_client_server_dual_socket_connect`: dual stack client connects to a dual stack server over IPv4 and IPv6, including to the server's second address (which fails without the whitelist fix), on real sockets.
- `client_server_socket_connect` now asserts the client actually connected and the server sees one client — previously a failed connection passed silently, which also hardens the 8 existing ipv4/ipv6 socket connect cases.
- soak.c: re-enables the server side of the soak test (uncomments the server create/start/update blocks).

## Verification

- Full test suite passes, both normally and under AddressSanitizer + UndefinedBehaviorSanitizer (macOS).
- End-to-end: server.c (dual) + client.c (dual) connect and exchange packets over both `127.0.0.1:40000` and `[::1]:40000` on real sockets, clean under ASan/UBSan.
- netcode.c compiles clean with `-Wall -Wextra`; parse fixes verified against a standalone harness — all previously-valid inputs unchanged, malformed inputs (`[`, `[]`, `[]:`) still rejected.

## Notes for reviewers

- The Linux packet tagging fix is verified by inspection and by symmetry with the Mac block — I could not compile the Linux branch on macOS, so a Linux CI run is worth doing before merge.
- Known issue left unfixed (pre-existing): profile.c line 164 sends to client `0` instead of `client_index` inside the per-client loop, and the newly re-enabled soak.c server block has the same hardcoded `0`. Can fix in this PR or a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)