### PR TITLE
Set CMake project version to 1.3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(netcode VERSION 1.3.1 LANGUAGES C CXX)
+project(netcode VERSION 1.3.3 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)


### PR DESCRIPTION
The v1.3.2 release left `project()` at 1.3.1, so the shared library VERSION metadata (e.g. `libnetcode.1.3.1.dylib`) doesn't match the release it ships in — spotted while packaging v1.3.2 for homebrew-core. One-line fix, bumped straight to 1.3.3 so the tree matches the tag that will ship it. No library code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)