### PR TITLE
Add BSD support (OpenBSD, FreeBSD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(netcode VERSION 1.3.4 LANGUAGES C CXX)
+project(netcode VERSION 1.3.5 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/netcode.c
+++ b/netcode.c
@@ -680,20 +680,43 @@ int netcode_socket_create( struct netcode_socket_t * s, struct netcode_address_t
         }
     }
 
-    // increase socket send and receive buffer sizes
+    // increase socket send and receive buffer sizes. linux and windows clamp requests that
+    // exceed the OS limit, but the BSDs reject them instead, so back off until accepted.
 
-    if ( setsockopt( s->handle, SOL_SOCKET, SO_SNDBUF, (char*)&send_buffer_size, sizeof(int) ) != 0 )
     {
-        netcode_printf( NETCODE_LOG_LEVEL_ERROR, "error: failed to set socket send buffer size\n" );
-        netcode_socket_destroy( s );
-        return NETCODE_SOCKET_ERROR_SOCKOPT_SNDBUF_FAILED;
+        int size = send_buffer_size;
+        while ( setsockopt( s->handle, SOL_SOCKET, SO_SNDBUF, (char*)&size, sizeof(int) ) != 0 )
+        {
+            size /= 2;
+            if ( size < 256 * 1024 )
+            {
+                netcode_printf( NETCODE_LOG_LEVEL_ERROR, "error: failed to set socket send buffer size\n" );
+                netcode_socket_destroy( s );
+                return NETCODE_SOCKET_ERROR_SOCKOPT_SNDBUF_FAILED;
+            }
+        }
+        if ( size != send_buffer_size )
+        {
+            netcode_printf( NETCODE_LOG_LEVEL_INFO, "socket send buffer size reduced from %d to %d\n", send_buffer_size, size );
+        }
     }
 
-    if ( setsockopt( s->handle, SOL_SOCKET, SO_RCVBUF, (char*)&receive_buffer_size, sizeof(int) ) != 0 )
     {
-        netcode_printf( NETCODE_LOG_LEVEL_ERROR, "error: failed to set socket receive buffer size\n" );
-        netcode_socket_destroy( s );
-        return NETCODE_SOCKET_ERROR_SOCKOPT_RCVBUF_FAILED;
+        int size = receive_buffer_size;
+        while ( setsockopt( s->handle, SOL_SOCKET, SO_RCVBUF, (char*)&size, sizeof(int) ) != 0 )
+        {
+            size /= 2;
+            if ( size < 256 * 1024 )
+            {
+                netcode_printf( NETCODE_LOG_LEVEL_ERROR, "error: failed to set socket receive buffer size\n" );
+                netcode_socket_destroy( s );
+                return NETCODE_SOCKET_ERROR_SOCKOPT_RCVBUF_FAILED;
+            }
+        }
+        if ( size != receive_buffer_size )
+        {
+            netcode_printf( NETCODE_LOG_LEVEL_INFO, "socket receive buffer size reduced from %d to %d\n", receive_buffer_size, size );
+        }
     }
 
     // bind to port

--- a/netcode.c
+++ b/netcode.c
@@ -5325,7 +5325,7 @@ int netcode_generate_connect_token( int num_server_addresses,
 
 // ---------------------------------------------------------------
 
-#if __APPLE__
+#if NETCODE_PLATFORM == NETCODE_PLATFORM_MAC
 
 // MacOS
 
@@ -5356,11 +5356,19 @@ double netcode_time()
     return ( (double) ( current - start ) ) * ( (double) timebase_info.numer ) / ( (double) timebase_info.denom ) / 1000000000.0;
 }
 
-#elif __linux
+#elif NETCODE_PLATFORM == NETCODE_PLATFORM_UNIX
 
-// linux
+// linux and other unix systems (openbsd, freebsd etc.)
 
 #include <unistd.h>
+
+// linux has CLOCK_MONOTONIC_RAW, but other unix systems only have CLOCK_MONOTONIC
+
+#ifdef CLOCK_MONOTONIC_RAW
+#define NETCODE_MONOTONIC_CLOCK CLOCK_MONOTONIC_RAW
+#else
+#define NETCODE_MONOTONIC_CLOCK CLOCK_MONOTONIC
+#endif
 
 void netcode_sleep( double time )
 {
@@ -5376,17 +5384,17 @@ double netcode_time()
     if ( start == -1 )
     {
         struct timespec ts;
-        clock_gettime( CLOCK_MONOTONIC_RAW, &ts );
+        clock_gettime( NETCODE_MONOTONIC_CLOCK, &ts );
         start = ts.tv_sec + ( (double) ( ts.tv_nsec ) ) / 1000000000.0;
         return 0.0;
     }
     struct timespec ts;
-    clock_gettime( CLOCK_MONOTONIC_RAW, &ts );
+    clock_gettime( NETCODE_MONOTONIC_CLOCK, &ts );
     double current = ts.tv_sec + ( (double) ( ts.tv_nsec ) ) / 1000000000.0;
     return current - start;
 }
 
-#elif defined( _WIN32 )
+#elif NETCODE_PLATFORM == NETCODE_PLATFORM_WINDOWS
 
 // windows
 

--- a/netcode.h
+++ b/netcode.h
@@ -25,10 +25,10 @@
 #ifndef NETCODE_H
 #define NETCODE_H
 
-#define NETCODE_VERSION_FULL    "1.3.4"
+#define NETCODE_VERSION_FULL    "1.3.5"
 #define NETCODE_VERSION_MAJOR   1
 #define NETCODE_VERSION_MINOR   3
-#define NETCODE_VERSION_PATCH   4
+#define NETCODE_VERSION_PATCH   5
 
 /*
     IMPORTANT: netcode is single-threaded by design and is not thread safe.


### PR DESCRIPTION
Two fixes that make netcode build and pass its full test suite on the BSDs, verified on OpenBSD 7.9/arm64 (all 44 tests) and macOS/Linux via CI:

- The time/sleep platform block now covers all unix systems via `NETCODE_PLATFORM_UNIX` instead of only `__linux`, and falls back to `CLOCK_MONOTONIC` on systems without the linux-specific `CLOCK_MONOTONIC_RAW`.
- Socket creation backs off SO_SNDBUF/SO_RCVBUF requests to the OS limit instead of failing: the BSDs reject requests above sb_max / kern.ipc.maxsockbuf (both default 2MB) with ENOBUFS instead of clamping like linux and windows, so the default 4MB request made every socket create fail. The request is halved until accepted (floor 256KB) and a reduction is logged at INFO level.

Version is bumped to 1.3.5. This unblocks the OpenBSD ports submission (and FreeBSD packaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)