### PR TITLE
Conformance checker: STANDARD.md vs the implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,19 @@ jobs:
             fuzz-run/oom-*
             fuzz-run/timeout-*
           if-no-files-found: ignore
+
+  conformance:
+    name: STANDARD.md conformance
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # Checks the wire-format specification against the implementation. The
+      # checker parses artifacts the real library produces using ONLY what
+      # STANDARD.md states, with no reference to the source. A failure means
+      # the document and the code disagree — decide which is wrong, and fix
+      # that one. A specification nothing verifies drifts, and a drifted spec
+      # is worse than none because independent implementations are built on it.
+      - name: Verify STANDARD.md
+        run: python3 tools/conformance/verify_standard.py
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,9 @@ jobs:
       - name: Verify STANDARD.md
         run: python3 tools/conformance/verify_standard.py
 
+
+      # Behaviour over time rather than bytes on the wire: drives a real client
+      # and server through a full connection lifecycle and checks every state
+      # transition against the machine STANDARD.md specifies.
+      - name: Verify STANDARD.md client state machine
+        run: python3 tools/conformance/verify_state_machine.py

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+# .mailmap — canonical identities for git log, shortlog and blame.
+#
+# Git treats every distinct name/email pair as a different person. Without this
+# file, an ownership or contribution analysis silently miscounts: Glenn commits
+# under five identities across these repositories, and attributing four of them
+# to strangers inflates the apparent third-party share of the codebase by
+# thousands of lines. That is not hypothetical — it happened, on 2026-07-21,
+# during a copyright-ownership review, and was caught only by resolving authors
+# by email instead of by name.
+#
+# Contributors: if your entry here is wrong, or you would rather be credited
+# under a different name, send a patch. This file exists to credit people
+# accurately, not to overrule how they wish to be named.
+#
+# Format:  Canonical Name <canonical@email>  Commit Name <commit@email>
+
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn@networknext.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> gafferongames <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn Fiedler <Glenn Fiedler>
+
+Jérôme Leclercq <lynix680@gmail.com> Lynix <lynix680@gmail.com>
+Val Vanderschaegen <valere.vanderschaegen@gmail.com> Val V <valere.vanderschaegen@gmail.com>
+NX <nxrighthere@gmail.com> nxrighthere <nxrighthere@gmail.com>
+Vavius <vavius@gmail.com> vavius <vavius@gmail.com>
+Kien Hoang <kienhg96@gmail.com> Hoang Kien <kienhg96@gmail.com>
+Ryan Scott <ryan@ryan-scott.me> Ryan <ryan@ryan-scott.me>

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -61,8 +61,13 @@ deterministically by a token pointed at an address where nothing listens
 (drive_error_paths.c). It confirms the machine takes the licensed failure route
 — sending-request -> request-timed-out — rather than some other path.
 
-The other five error states remain untaken: denied, the response and connection
-timeouts, and expired/invalid tokens. Denied and the later timeouts need a
-server that rejects or goes silent mid-handshake; the token errors need
-deliberate token corruption. Each is worth adding; the request timeout was the
-one provokable with no server at all.
+Two error paths are now exercised: the connection-REQUEST timeout (dead
+address) and INVALID_CONNECT_TOKEN (num_server_addresses corrupted to 0 — the
+client rejects before it ever sends, and the driver self-verifies the byte
+offset by asserting the pre-corruption value).
+
+Three error states remain untaken, and honestly so: CONNECT_TOKEN_EXPIRED needs
+wall-clock manipulation (generate_connect_token stamps real time, the drivers
+run on simulated time); CONNECTION_DENIED and CONNECTION_RESPONSE_TIMED_OUT need
+a server that rejects or goes silent mid-handshake. Worth adding when a
+configurable test server exists.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -50,10 +50,11 @@ libsodium's xchacha20poly1305 against the same keys — which tests the crypto
 library, not the specification. The plaintext framing is what an independent
 implementation gets wrong, and that is what is covered here.
 
-The SERVER-side connection process is still unverified — slot allocation,
-connection request handling, and the per-slot lifecycle. The client state
-machine now has a checker (above); the server's would need a second driver that
-inspects server state rather than client state.
+The server-side connection process now has coverage too (drive_server.c):
+baseline zero clients, a client connecting into a valid slot with its own id
+visible to the server, num_connected tracking, no spurious idle change, and the
+slot freeing on disconnect. What remains on the server side: multi-client slot
+allocation (only one client is driven here) and server-side rejection paths.
 
 ONE error path is now exercised: the connection-request timeout, provoked
 deterministically by a token pointed at an address where nothing listens

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -1,0 +1,33 @@
+# Conformance: STANDARD.md vs the implementation
+
+`STANDARD.md` is the public protocol specification. Independent implementations
+— including the Go and Rust ports — are written against it, so if it drifts
+from `netcode.c` those implementations are wrong and nobody finds out.
+
+This checks the two against each other. `gen_vectors.c` links the real library
+and emits artifacts; `verify_standard.py` parses them using **only what
+STANDARD.md says**, with no reference to netcode.c, and asserts every field.
+
+    python3 tools/conformance/verify_standard.py
+
+Exit 0 means the document and the code agree. A failure means one of them is
+wrong — decide which, and fix that one.
+
+## What is covered
+
+* the 2048-byte connect token: every public field, both address forms, and the
+  zero padding
+* the packet prefix byte: type in the low 4 bits, sequence byte count in the high 4
+* the variable-length sequence encoding, including that the byte count is
+  **minimal** (high zero bytes omitted) and the little-endian order
+
+## What is NOT covered, and why
+
+Encrypted packet bodies. Everything from the sequence number onward in packet
+types >= 1 is AEAD-encrypted, so checking it would mean reimplementing
+libsodium's xchacha20poly1305 against the same keys — which tests the crypto
+library, not the specification. The plaintext framing is what an independent
+implementation gets wrong, and that is what is covered here.
+
+Challenge tokens and the client/server state machines are also unverified. They
+are specified in STANDARD.md and would be worth adding.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -23,6 +23,25 @@ wrong — decide which, and fix that one.
 * the challenge token's plaintext layout: client id, 256 bytes of user data,
   the zero pad to 300, and that the pad leaves room for the 16-byte HMAC
 
+## The client state machine, separately
+
+`verify_state_machine.py` checks the client state machine STANDARD.md specifies
+— behaviour over time rather than bytes on the wire, so a different instrument.
+It drives a real client and server through a full connection lifecycle over UDP,
+records every state transition, and checks that:
+
+* the initial state is *disconnected*;
+* every observed transition is one the document permits (all ten states and
+  their licensed transitions are transcribed into the checker);
+* the happy path is exactly *disconnected -> sending connection request ->
+  sending challenge response -> connected -> disconnected*;
+* nothing reaches *connected* except from *sending challenge response* — the
+  document admits exactly one route to the goal state;
+* a connected, idle client produces **no** transitions at all;
+* a clean disconnect ends in *disconnected* and never in an error state.
+
+    python3 tools/conformance/verify_state_machine.py
+
 ## What is NOT covered, and why
 
 Encrypted packet bodies. Everything from the sequence number onward in packet
@@ -31,6 +50,12 @@ libsodium's xchacha20poly1305 against the same keys — which tests the crypto
 library, not the specification. The plaintext framing is what an independent
 implementation gets wrong, and that is what is covered here.
 
-The client and server state machines are also unverified. They are specified in
-STANDARD.md but they are behaviour over time rather than bytes on the wire, so
-they belong in a behavioural test rather than here.
+The SERVER-side connection process is still unverified — slot allocation,
+connection request handling, and the per-slot lifecycle. The client state
+machine now has a checker (above); the server's would need a second driver that
+inspects server state rather than client state.
+
+Only the happy path is exercised. The error transitions — denied, the three
+timeouts, expired and invalid tokens — are transcribed into the checker's legal
+set but never taken, because the driver connects successfully every time.
+Provoking them needs a hostile or absent server, which is worth adding.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -20,6 +20,8 @@ wrong — decide which, and fix that one.
 * the packet prefix byte: type in the low 4 bits, sequence byte count in the high 4
 * the variable-length sequence encoding, including that the byte count is
   **minimal** (high zero bytes omitted) and the little-endian order
+* the challenge token's plaintext layout: client id, 256 bytes of user data,
+  the zero pad to 300, and that the pad leaves room for the 16-byte HMAC
 
 ## What is NOT covered, and why
 
@@ -29,5 +31,6 @@ libsodium's xchacha20poly1305 against the same keys — which tests the crypto
 library, not the specification. The plaintext framing is what an independent
 implementation gets wrong, and that is what is covered here.
 
-Challenge tokens and the client/server state machines are also unverified. They
-are specified in STANDARD.md and would be worth adding.
+The client and server state machines are also unverified. They are specified in
+STANDARD.md but they are behaviour over time rather than bytes on the wire, so
+they belong in a behavioural test rather than here.

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -55,7 +55,13 @@ connection request handling, and the per-slot lifecycle. The client state
 machine now has a checker (above); the server's would need a second driver that
 inspects server state rather than client state.
 
-Only the happy path is exercised. The error transitions — denied, the three
-timeouts, expired and invalid tokens — are transcribed into the checker's legal
-set but never taken, because the driver connects successfully every time.
-Provoking them needs a hostile or absent server, which is worth adding.
+ONE error path is now exercised: the connection-request timeout, provoked
+deterministically by a token pointed at an address where nothing listens
+(drive_error_paths.c). It confirms the machine takes the licensed failure route
+— sending-request -> request-timed-out — rather than some other path.
+
+The other five error states remain untaken: denied, the response and connection
+timeouts, and expired/invalid tokens. Denied and the later timeouts need a
+server that rejects or goes silent mid-handshake; the token errors need
+deliberate token corruption. Each is worth adding; the request timeout was the
+one provokable with no server at all.

--- a/tools/conformance/drive_error_paths.c
+++ b/tools/conformance/drive_error_paths.c
@@ -1,0 +1,75 @@
+/*
+    Drives a real netcode client through a connection-request timeout scenario
+    and prints every client state transition, for verify_state_machine.py.
+
+    Output:  STATE <from> <to> <phase>
+             RESULT <ok|fail> <note>
+*/
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "netcode.h"
+
+static int last_state = -999;
+
+static void note( struct netcode_client_t * client, const char * phase )
+{
+    int s = netcode_client_state( client );
+    if ( s != last_state )
+    {
+        printf( "STATE %d %d %s\n", last_state == -999 ? 0 : last_state, s, phase );
+        last_state = s;
+    }
+}
+
+int main( void )
+{
+    setvbuf( stdout, NULL, _IONBF, 0 );
+
+    if ( netcode_init() != NETCODE_OK ) { printf( "RESULT fail init\n" ); return 1; }
+    netcode_log_level( NETCODE_LOG_LEVEL_NONE );
+
+    double time = 100.0;
+    const double dt = 0.1;
+    uint8_t private_key[NETCODE_KEY_BYTES];
+    memset( private_key, 0, sizeof( private_key ) );
+
+    struct netcode_client_config_t client_config;
+    netcode_default_client_config( &client_config );
+
+    struct netcode_client_t * client = netcode_client_create( "0.0.0.0", &client_config, time );
+    if ( !client ) { printf( "RESULT fail client_create\n" ); return 1; }
+
+    /* the initial state, before anything is asked of the client */
+    note( client, "initial" );
+
+    uint64_t client_id = 0x1234567890ABCDEFULL;
+    uint8_t user_data[NETCODE_USER_DATA_BYTES];
+    memset( user_data, 0, sizeof( user_data ) );
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    NETCODE_CONST char * server_addresses[] = { "127.0.0.1:40501" };
+
+    if ( netcode_generate_connect_token( 1, server_addresses, server_addresses, 30, 5,
+                                         client_id, 0x1122334455667788ULL,
+                                         private_key, user_data, connect_token ) != NETCODE_OK )
+    { printf( "RESULT fail token\n" ); return 1; }
+
+    netcode_client_connect( client, connect_token );
+    note( client, "after_connect_call" );
+
+    int i;
+    for ( i = 0; i < 2000; i++ )
+    {
+        netcode_client_update( client, time );
+        note( client, "waiting" );
+        if ( netcode_client_state( client ) < NETCODE_CLIENT_STATE_DISCONNECTED )
+        { printf( "RESULT ok reached_error\n" ); return 0; }
+        time += dt;
+    }
+
+    printf( "RESULT fail no_error_state\n" );
+
+    netcode_client_destroy( client );
+    netcode_term();
+    return 1;
+}

--- a/tools/conformance/drive_invalid_token.c
+++ b/tools/conformance/drive_invalid_token.c
@@ -1,0 +1,96 @@
+/*
+    Drives a real netcode client through an invalid connect token scenario
+    and prints every client state transition, for verify_state_machine.py.
+
+    Output:  STATE <from> <to> <phase>
+             RESULT <ok|fail> <note>
+*/
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "netcode.h"
+
+static int last_state = -999;
+
+static void note( struct netcode_client_t * client, const char * phase )
+{
+    int s = netcode_client_state( client );
+    if ( s != last_state )
+    {
+        printf( "STATE %d %d %s\n", last_state == -999 ? 0 : last_state, s, phase );
+        last_state = s;
+    }
+}
+
+int main( void )
+{
+    setvbuf( stdout, NULL, _IONBF, 0 );
+
+    if ( netcode_init() != NETCODE_OK ) { printf( "RESULT fail init\n" ); return 1; }
+    netcode_log_level( NETCODE_LOG_LEVEL_NONE );
+
+    double time = 100.0;
+    const double dt = 0.1;
+    uint8_t private_key[NETCODE_KEY_BYTES];
+    memset( private_key, 0, sizeof( private_key ) );
+    uint8_t user_data[NETCODE_USER_DATA_BYTES];
+    memset( user_data, 0, sizeof( user_data ) );
+
+    char addr[64];
+    snprintf(addr, sizeof(addr), "127.0.0.1:40502");
+    NETCODE_CONST char * server_addresses[] = { addr };
+
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    if ( netcode_generate_connect_token( 1, server_addresses, server_addresses, 30, 5,
+                                         0x1234567890ABCDEFULL, 0x1122334455667788ULL,
+                                         private_key, user_data, connect_token ) != NETCODE_OK )
+    { printf( "RESULT fail token\n" ); return 1; }
+
+    const int NUM_ADDR_OFFSET = 13 + 8 + 8 + 8 + 24 + 1024 + 4;
+    uint32_t num_server_addresses = (connect_token[NUM_ADDR_OFFSET] |
+                                    (connect_token[NUM_ADDR_OFFSET + 1] << 8) |
+                                    (connect_token[NUM_ADDR_OFFSET + 2] << 16) |
+                                    (connect_token[NUM_ADDR_OFFSET + 3] << 24));
+    if (num_server_addresses != 1)
+    {
+        printf( "RESULT fail offset_wrong got=%u\n", num_server_addresses );
+        return 1;
+    }
+
+    connect_token[NUM_ADDR_OFFSET] = 0;
+    connect_token[NUM_ADDR_OFFSET + 1] = 0;
+    connect_token[NUM_ADDR_OFFSET + 2] = 0;
+    connect_token[NUM_ADDR_OFFSET + 3] = 0;
+
+    struct netcode_client_config_t client_config;
+    netcode_default_client_config( &client_config );
+
+    struct netcode_client_t * client = netcode_client_create( "0.0.0.0", &client_config, time );
+    if ( !client ) { printf( "RESULT fail client_create\n" ); return 1; }
+
+    note( client, "initial" );
+
+    netcode_client_connect( client, connect_token );
+    note( client, "after_connect_call" );
+
+    int i;
+    for ( i = 0; i < 200; i++ )
+    {
+        netcode_client_update( client, time );
+        note( client, "validating" );
+        if ( netcode_client_state( client ) < NETCODE_CLIENT_STATE_DISCONNECTED )
+            break;
+        time += dt;
+    }
+
+    int final_state = netcode_client_state( client );
+    if ( final_state == NETCODE_CLIENT_STATE_INVALID_CONNECT_TOKEN )
+        printf( "RESULT ok invalid_token\n" );
+    else
+        printf( "RESULT fail state=%d\n", final_state );
+
+    netcode_client_destroy( client );
+    netcode_term();
+    return 0;
+}

--- a/tools/conformance/drive_server.c
+++ b/tools/conformance/drive_server.c
@@ -1,0 +1,131 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "netcode.h"
+
+int main(void)
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    if (netcode_init() != NETCODE_OK) {
+        printf("RESULT fail init\n");
+        return 1;
+    }
+    netcode_log_level(NETCODE_LOG_LEVEL_NONE);
+
+    double time = 100.0;
+    const double dt = 0.05;
+    uint8_t private_key[NETCODE_KEY_BYTES];
+    memset(private_key, 0, sizeof(private_key));
+
+    char addr[64];
+    snprintf(addr, sizeof(addr), "127.0.0.1:42000");
+
+    struct netcode_server_config_t server_config;
+    netcode_default_server_config(&server_config);
+    server_config.protocol_id = 0x1122334455667788ULL;
+    memcpy(server_config.private_key, private_key, NETCODE_KEY_BYTES);
+
+    struct netcode_server_t *server = netcode_server_create(addr, &server_config, time);
+    if (!server) {
+        printf("RESULT fail server_create\n");
+        return 1;
+    }
+    netcode_server_start(server, 4);
+
+    int max_clients = netcode_server_max_clients(server);
+    int num_connected = netcode_server_num_connected_clients(server);
+    printf("SLOT baseline -1 %d max=%d\n", num_connected, max_clients);
+
+    struct netcode_client_config_t client_config;
+    netcode_default_client_config(&client_config);
+
+    struct netcode_client_t *client = netcode_client_create("0.0.0.0", &client_config, time);
+    if (!client) {
+        printf("RESULT fail client_create\n");
+        return 1;
+    }
+
+    uint64_t client_id = 0x1234567890ABCDEFULL;
+    uint8_t user_data[NETCODE_USER_DATA_BYTES];
+    memset(user_data, 0, sizeof(user_data));
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+
+    NETCODE_CONST char * server_addresses[] = { addr };
+    if (netcode_generate_connect_token(1, server_addresses, server_addresses, 30, 5,
+                                         client_id, server_config.protocol_id,
+                                         private_key, user_data, connect_token) != NETCODE_OK) {
+        printf("RESULT fail token\n");
+        return 1;
+    }
+
+    netcode_client_connect(client, connect_token);
+
+    int connected_slots[max_clients];
+    memset(connected_slots, 0, sizeof(connected_slots));
+
+    for (int i = 0; i < 400; i++) {
+        netcode_client_update(client, time);
+        netcode_server_update(server, time);
+
+        num_connected = netcode_server_num_connected_clients(server);
+        for (int j = 0; j < max_clients; j++) {
+            if (netcode_server_client_connected(server, j)) {
+                if (!connected_slots[j]) {
+                    printf("SLOT connected %d %d id=%llu\n", j, num_connected, netcode_server_client_id(server, j));
+                    connected_slots[j] = 1;
+                }
+            }
+        }
+
+        if (netcode_client_state(client) == NETCODE_CLIENT_STATE_CONNECTED) break;
+
+        time += dt;
+    }
+
+    if (netcode_client_state(client) != NETCODE_CLIENT_STATE_CONNECTED) {
+        printf("RESULT fail never_connected\n");
+        netcode_client_destroy(client);
+        netcode_server_destroy(server);
+        netcode_term();
+        return 1;
+    }
+
+    for (int i = 0; i < 20; i++) {
+        int prev_num_connected = num_connected;
+        netcode_client_update(client, time);
+        netcode_server_update(server, time);
+
+        num_connected = netcode_server_num_connected_clients(server);
+        if (num_connected != prev_num_connected) {
+            printf("SLOT changed_while_idle -1 %d\n", num_connected);
+        }
+
+        time += dt;
+    }
+
+    netcode_client_disconnect(client);
+
+    for (int i = 0; i < 100; i++) {
+        netcode_client_update(client, time);
+        netcode_server_update(server, time);
+
+        num_connected = netcode_server_num_connected_clients(server);
+        for (int j = 0; j < max_clients; j++) {
+            if (!netcode_server_client_connected(server, j) && connected_slots[j]) {
+                printf("SLOT freed %d %d\n", j, num_connected);
+                connected_slots[j] = 0;
+                break;
+            }
+        }
+
+        time += dt;
+    }
+
+    printf("RESULT ok complete\n");
+
+    netcode_client_destroy(client);
+    netcode_server_destroy(server);
+    netcode_term();
+    return 0;
+}

--- a/tools/conformance/drive_state_machine.c
+++ b/tools/conformance/drive_state_machine.c
@@ -1,0 +1,114 @@
+/*
+    Drives a real netcode client and server through a full connection lifecycle
+    and prints every client state transition, for verify_state_machine.py.
+
+    Output:  STATE <from> <to> <phase>
+             RESULT <ok|fail> <note>
+*/
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "netcode.h"
+
+#define CONFORMANCE_PORT 41999
+
+static int last_state = -999;
+
+static void note( struct netcode_client_t * client, const char * phase )
+{
+    int s = netcode_client_state( client );
+    if ( s != last_state )
+    {
+        printf( "STATE %d %d %s\n", last_state == -999 ? 0 : last_state, s, phase );
+        last_state = s;
+    }
+}
+
+int main( void )
+{
+    setvbuf( stdout, NULL, _IONBF, 0 );
+
+    if ( netcode_init() != NETCODE_OK ) { printf( "RESULT fail init\n" ); return 1; }
+    netcode_log_level( NETCODE_LOG_LEVEL_NONE );
+
+    double time = 100.0;
+    const double dt = 0.05;
+    uint8_t private_key[NETCODE_KEY_BYTES];
+    memset( private_key, 0, sizeof( private_key ) );
+
+    char addr[64];
+    snprintf( addr, sizeof( addr ), "127.0.0.1:%d", CONFORMANCE_PORT );
+
+    struct netcode_server_config_t server_config;
+    netcode_default_server_config( &server_config );
+    server_config.protocol_id = 0x1122334455667788ULL;
+    memcpy( server_config.private_key, private_key, NETCODE_KEY_BYTES );
+
+    struct netcode_server_t * server = netcode_server_create( addr, &server_config, time );
+    if ( !server ) { printf( "RESULT fail server_create\n" ); return 1; }
+    netcode_server_start( server, 4 );
+
+    struct netcode_client_config_t client_config;
+    netcode_default_client_config( &client_config );
+
+    struct netcode_client_t * client = netcode_client_create( "0.0.0.0", &client_config, time );
+    if ( !client ) { printf( "RESULT fail client_create\n" ); return 1; }
+
+    /* the initial state, before anything is asked of the client */
+    note( client, "initial" );
+
+    uint64_t client_id = 0x1234567890ABCDEFULL;
+    uint8_t user_data[NETCODE_USER_DATA_BYTES];
+    memset( user_data, 0, sizeof( user_data ) );
+    uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
+    NETCODE_CONST char * server_addresses[] = { addr };
+
+    if ( netcode_generate_connect_token( 1, server_addresses, server_addresses, 30, 5,
+                                         client_id, server_config.protocol_id,
+                                         private_key, user_data, connect_token ) != NETCODE_OK )
+    { printf( "RESULT fail token\n" ); return 1; }
+
+    netcode_client_connect( client, connect_token );
+    note( client, "after_connect_call" );
+
+    int i;
+    for ( i = 0; i < 400; i++ )
+    {
+        netcode_client_update( client, time );
+        netcode_server_update( server, time );
+        note( client, "handshake" );
+        if ( netcode_client_state( client ) == NETCODE_CLIENT_STATE_CONNECTED ) break;
+        if ( netcode_client_state( client ) < NETCODE_CLIENT_STATE_DISCONNECTED )
+        { printf( "RESULT fail handshake_error\n" ); return 1; }
+        time += dt;
+    }
+    if ( netcode_client_state( client ) != NETCODE_CLIENT_STATE_CONNECTED )
+    { printf( "RESULT fail never_connected\n" ); return 1; }
+
+    /* hold the connection so a spurious transition would show up */
+    for ( i = 0; i < 40; i++ )
+    {
+        netcode_client_update( client, time );
+        netcode_server_update( server, time );
+        note( client, "steady" );
+        time += dt;
+    }
+
+    netcode_client_disconnect( client );
+    note( client, "after_disconnect_call" );
+
+    for ( i = 0; i < 20; i++ )
+    {
+        netcode_client_update( client, time );
+        netcode_server_update( server, time );
+        note( client, "post_disconnect" );
+        time += dt;
+    }
+
+    printf( "RESULT ok complete\n" );
+
+    netcode_client_destroy( client );
+    netcode_server_destroy( server );
+    netcode_term();
+    return 0;
+}

--- a/tools/conformance/gen_vectors.c
+++ b/tools/conformance/gen_vectors.c
@@ -4,6 +4,8 @@
 #include "netcode.h"
 struct keep_alive_t { uint8_t packet_type; int client_index; int max_clients; };
 int netcode_write_packet( void*, uint8_t*, int, uint64_t, uint8_t*, uint64_t );
+struct netcode_challenge_token_t;
+void netcode_write_challenge_token( struct netcode_challenge_token_t *, uint8_t *, int );
 static void dump(const char*tag, uint8_t*b, int n){
     printf("%s %d ", tag, n);
     for(int i=0;i<n;i++) printf("%02x", b[i]);
@@ -28,6 +30,16 @@ int main(void){
         int n=netcode_write_packet(&ka,buf,sizeof(buf),seqs[s],key,0x1234567890ABCDEFULL);
         if(n<=0){fprintf(stderr,"write_packet failed seq=%llu\n",(unsigned long long)seqs[s]);return 1;}
         printf("PKT %llu ", (unsigned long long)seqs[s]); dump("", buf, n);
+    }
+
+    /* challenge token, plaintext layout per STANDARD.md "Challenge Token" */
+    {
+        struct { uint64_t client_id; uint8_t user_data[256]; } ct;
+        ct.client_id = 0x0102030405060708ULL;
+        for ( int i = 0; i < 256; i++ ) ct.user_data[i] = (uint8_t)( i ^ 0x5A );
+        uint8_t cbuf[300];
+        netcode_write_challenge_token( (struct netcode_challenge_token_t*) &ct, cbuf, sizeof(cbuf) );
+        dump( "CHALLENGE", cbuf, 300 );
     }
     return 0;
 }

--- a/tools/conformance/gen_vectors.c
+++ b/tools/conformance/gen_vectors.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "netcode.h"
+struct keep_alive_t { uint8_t packet_type; int client_index; int max_clients; };
+int netcode_write_packet( void*, uint8_t*, int, uint64_t, uint8_t*, uint64_t );
+static void dump(const char*tag, uint8_t*b, int n){
+    printf("%s %d ", tag, n);
+    for(int i=0;i<n;i++) printf("%02x", b[i]);
+    printf("\n");
+}
+int main(void){
+    netcode_init();
+    uint8_t key[32]; for(int i=0;i<32;i++) key[i]=(uint8_t)i;
+    uint8_t user[256]; for(int i=0;i<256;i++) user[i]=(uint8_t)(255-i);
+    uint8_t token[2048];
+    const char *pub[2]={"127.0.0.1:40000","[::1]:40001"};
+    const char *inn[2]={"127.0.0.1:40000","[::1]:40001"};
+    if(netcode_generate_connect_token(2,(NETCODE_CONST char**)pub,(NETCODE_CONST char**)inn,
+        45,17,0x1122334455667788ULL,0x1234567890ABCDEFULL,key,user,token)!=NETCODE_OK){
+        fprintf(stderr,"token gen failed\n"); return 1; }
+    dump("TOKEN", token, 2048);
+    // packets: exercise the variable-length sequence encoding across byte boundaries
+    uint64_t seqs[]={0,1,255,256,65535,65536,0xFFFFFF,0x1000000,0xFFFFFFFFFFULL,0xFFFFFFFFFFFFFFFFULL};
+    for(unsigned s=0;s<sizeof(seqs)/sizeof(seqs[0]);s++){
+        struct keep_alive_t ka={6+0,3,32}; ka.packet_type=4; /* keep alive */
+        uint8_t buf[4096];
+        int n=netcode_write_packet(&ka,buf,sizeof(buf),seqs[s],key,0x1234567890ABCDEFULL);
+        if(n<=0){fprintf(stderr,"write_packet failed seq=%llu\n",(unsigned long long)seqs[s]);return 1;}
+        printf("PKT %llu ", (unsigned long long)seqs[s]); dump("", buf, n);
+    }
+    return 0;
+}

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -42,10 +42,12 @@ def main():
     ap.add_argument("--cc", default=os.environ.get("CC", "cc"))
     a = ap.parse_args()
 
-    token, packets = None, []
+    token, packets, challenge = None, [], None
     for line in build_and_run(a.cc).splitlines():
         if line.startswith("TOKEN "):
             _, n, h = line.split(); token = bytes.fromhex(h); assert int(n) == len(token)
+        elif line.startswith("CHALLENGE "):
+            _, n, h = line.split(); challenge = bytes.fromhex(h); assert int(n) == len(challenge)
         elif line.startswith("PKT "):
             p = line.split(); packets.append((int(p[1]), bytes.fromhex(p[3])))
     if token is None or not packets:
@@ -96,6 +98,17 @@ def main():
         for i in range(nseq):
             v |= p[1 + i] << (8 * i)
         c.eq(f"seq {seq}: sequence round-trips", v, seq)
+
+    # ---- Challenge token. STANDARD.md, "Prior to encryption, challenge tokens have the following structure"
+    if challenge is not None:
+        c.eq("challenge token size (zero pad to 300)", len(challenge), 300)
+        c.eq("challenge client id", struct.unpack_from("<Q", challenge, 0)[0], 0x0102030405060708)
+        c.eq("challenge user data (256 bytes)",
+             challenge[8:8 + 256], bytes((i ^ 0x5A) for i in range(256)))
+        c.eq("challenge zero pad after client id + user data",
+             set(challenge[8 + 256:300]) or {0}, {0})
+        c.eq("challenge plaintext leaves room for the 16-byte HMAC",
+             300 - (8 + 256) >= 16, True)
 
     print(f"{c.n} checks against STANDARD.md, {len(c.fails)} failures")
     for f in c.fails: print("  FAIL " + f)

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Check netcode/STANDARD.md against the implementation.
+
+Parses artifacts produced by the real library using ONLY what STANDARD.md
+states. Nothing here consults netcode.c. If the document and the code disagree,
+this fails and one of them is wrong.
+
+usage: python3 tools/conformance/verify_standard.py [--cc CC]
+exit:  0 = they agree, 1 = they do not, 2 = could not build/run
+"""
+import argparse, os, struct, subprocess, sys, tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def build_and_run(cc):
+    src = os.path.join(ROOT, "tools", "conformance", "gen_vectors.c")
+    with tempfile.TemporaryDirectory() as tmp:
+        exe = os.path.join(tmp, "gen")
+        cmd = [cc, "-I" + ROOT, "-I" + os.path.join(ROOT, "sodium"), "-o", exe, src,
+               os.path.join(ROOT, "netcode.c"), os.path.join(ROOT, "sodium", "sodium.c")]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            print("build failed:\n" + r.stderr[:2000], file=sys.stderr)
+            sys.exit(2)
+        r = subprocess.run([exe], capture_output=True, text=True)
+        if r.returncode != 0:
+            print("generator failed:\n" + r.stderr[:2000], file=sys.stderr)
+            sys.exit(2)
+        return r.stdout
+
+
+class Checker:
+    def __init__(self): self.n = 0; self.fails = []
+    def eq(self, name, got, exp):
+        self.n += 1
+        if got != exp: self.fails.append(f"{name}: got {got!r}, STANDARD.md says {exp!r}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cc", default=os.environ.get("CC", "cc"))
+    a = ap.parse_args()
+
+    token, packets = None, []
+    for line in build_and_run(a.cc).splitlines():
+        if line.startswith("TOKEN "):
+            _, n, h = line.split(); token = bytes.fromhex(h); assert int(n) == len(token)
+        elif line.startswith("PKT "):
+            p = line.split(); packets.append((int(p[1]), bytes.fromhex(p[3])))
+    if token is None or not packets:
+        print("generator produced no vectors", file=sys.stderr); sys.exit(2)
+
+    c = Checker()
+
+    # ---- Connect token. STANDARD.md, "Together the public and private data form a connect token"
+    c.eq("connect token size", len(token), 2048)
+    o = 0
+    c.eq("version info", token[0:13], b"NETCODE 1.02\x00"); o = 13
+    c.eq("protocol id", struct.unpack_from("<Q", token, o)[0], 0x1234567890ABCDEF); o += 8
+    create = struct.unpack_from("<Q", token, o)[0]; o += 8
+    expire = struct.unpack_from("<Q", token, o)[0]; o += 8
+    c.eq("expire - create == expire_seconds", expire - create, 45)
+    o += 24        # connect token nonce
+    o += 1024      # encrypted private connect token data
+    c.eq("timeout seconds", struct.unpack_from("<i", token, o)[0], 17); o += 4
+    n_addr = struct.unpack_from("<I", token, o)[0]; o += 4
+    c.eq("num server addresses", n_addr, 2)
+    addrs = []
+    for _ in range(n_addr):
+        t = token[o]; o += 1
+        if t == 1:
+            q = token[o:o + 4]; o += 4
+            port = struct.unpack_from("<H", token, o)[0]; o += 2
+            addrs.append(".".join(str(x) for x in q) + f":{port}")
+        elif t == 2:
+            parts = struct.unpack_from("<8H", token, o); o += 16
+            port = struct.unpack_from("<H", token, o)[0]; o += 2
+            addrs.append("[" + ":".join(f"{x:x}" for x in parts) + f"]:{port}")
+        else:
+            c.fails.append(f"address type {t} is not 1 (IPv4) or 2 (IPv6)")
+    c.eq("address 0 (IPv4)", addrs[0], "127.0.0.1:40000")
+    c.eq("address 1 is IPv6 on port 40001",
+         addrs[1].startswith("[") and addrs[1].endswith(":40001"), True)
+    o += 32 + 32   # client->server key, server->client key
+    c.eq("zero pad to 2048", set(token[o:2048]) or {0}, {0})
+
+    # ---- Packets. STANDARD.md, "Prior to encryption, packet types >= 1"
+    for seq, p in packets:
+        prefix = p[0]
+        c.eq(f"seq {seq}: packet type (low 4 bits) is keep-alive", prefix & 0x0F, 4)
+        nseq = (prefix >> 4) & 0x0F
+        c.eq(f"seq {seq}: sequence byte count in [1,8]", 1 <= nseq <= 8, True)
+        c.eq(f"seq {seq}: high zero bytes omitted", nseq, max(1, (seq.bit_length() + 7) // 8))
+        v = 0
+        for i in range(nseq):
+            v |= p[1 + i] << (8 * i)
+        c.eq(f"seq {seq}: sequence round-trips", v, seq)
+
+    print(f"{c.n} checks against STANDARD.md, {len(c.fails)} failures")
+    for f in c.fails: print("  FAIL " + f)
+    if c.fails:
+        print("\nSTANDARD.md and the implementation disagree. One of them is wrong.")
+        return 1
+    print("\nSTANDARD.md matches the implementation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -163,6 +163,55 @@ def main():
                     fails.append("expected CONNECTION_REQUEST_TIMED_OUT, reached "
                                  + str([NAME.get(t,t) for _,t in emoves]))
 
+    # ---- server-side connection process. STANDARD.md's "Server-Side Connection
+    # Process": the server manages slots [0, max_clients); a client connects into
+    # a slot, the server sees it, and a disconnect frees the slot. The client
+    # state machine above never checks any of this.
+    srv_src = os.path.join(ROOT, "tools", "conformance", "drive_server.c")
+    checks += 1
+    if not os.path.exists(srv_src):
+        fails.append("drive_server.c is missing — the server-side phase cannot run")
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = os.path.join(tmp, "srv")
+            r = subprocess.run([a.cc, "-I" + ROOT, "-I" + os.path.join(ROOT, "sodium"),
+                                "-o", exe, srv_src, os.path.join(ROOT, "netcode.c"),
+                                os.path.join(ROOT, "sodium", "sodium.c")],
+                               capture_output=True, text=True)
+            if r.returncode != 0:
+                fails.append("server driver failed to build")
+            else:
+                out = subprocess.run([exe], capture_output=True, text=True, timeout=120).stdout
+                events, result, maxc = [], None, None
+                for line in out.splitlines():
+                    f = line.split()
+                    if f[0] == "SLOT":
+                        events.append(f[1:])
+                        if f[1] == "baseline":
+                            maxc = int(f[4].split("=")[1])
+                    elif f[0] == "RESULT":
+                        result = f[1:]
+                EXPECTED_ID = 0x1234567890ABCDEF
+                eq("server driver completed", result and result[0], "ok")
+                base = [e for e in events if e[0] == "baseline"]
+                conn = [e for e in events if e[0] == "connected"]
+                freed = [e for e in events if e[0] == "freed"]
+                idle = [e for e in events if e[0] == "changed_while_idle"]
+                eq("baseline: zero clients connected", base and base[0][2], "0")
+                eq("exactly one client connected", len(conn), 1)
+                if conn:
+                    slot, num = int(conn[0][1]), int(conn[0][2])
+                    eq("connect slot in [0, max_clients)", 0 <= slot < (maxc or 0), True)
+                    eq("num_connected is 1 at connect", num, 1)
+                    got_id = int(conn[0][3].split("=")[1])
+                    eq("server reports the client's own id", got_id, EXPECTED_ID)
+                eq("no spurious slot change while idle", idle, [])
+                eq("exactly one slot freed on disconnect", len(freed), 1)
+                if freed:
+                    eq("num_connected back to 0 after free", int(freed[0][2]), 0)
+                    if conn:
+                        eq("the freed slot is the one that connected", freed[0][1], conn[0][1])
+
     print(f"{checks} checks against STANDARD.md, {len(fails)} failures")
     print("  observed: " + " -> ".join([NAME.get(moves[0][0], "?")] + [NAME.get(t, "?") for _, t in moves]))
     for f in fails: print("  FAIL " + f)

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -212,6 +212,44 @@ def main():
                     if conn:
                         eq("the freed slot is the one that connected", freed[0][1], conn[0][1])
 
+    # ---- invalid connect token. STANDARD.md: the client validates the token
+    # BEFORE the connection attempt, and on a bad num_server_addresses transitions
+    # straight to INVALID_CONNECT_TOKEN without ever sending a request. The error
+    # path above covers a timeout mid-handshake; this covers pre-attempt rejection.
+    inv_src = os.path.join(ROOT, "tools", "conformance", "drive_invalid_token.c")
+    checks += 1
+    if not os.path.exists(inv_src):
+        fails.append("drive_invalid_token.c is missing — the invalid-token phase cannot run")
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = os.path.join(tmp, "inv")
+            r = subprocess.run([a.cc, "-I" + ROOT, "-I" + os.path.join(ROOT, "sodium"),
+                                "-o", exe, inv_src, os.path.join(ROOT, "netcode.c"),
+                                os.path.join(ROOT, "sodium", "sodium.c")],
+                               capture_output=True, text=True)
+            if r.returncode != 0:
+                fails.append("invalid-token driver failed to build")
+            else:
+                out = subprocess.run([exe], capture_output=True, text=True, timeout=120).stdout
+                imoves, iresult = [], None
+                for line in out.splitlines():
+                    f = line.split()
+                    if f[0] == "STATE" and int(f[1]) != int(f[2]):
+                        imoves.append((int(f[1]), int(f[2])))
+                    elif f[0] == "RESULT":
+                        iresult = f[1:]
+                eq("invalid-token driver reached the rejection", iresult and iresult[0], "ok")
+                for frm, to in imoves:
+                    checks += 1
+                    if (frm, to) not in LEGAL:
+                        fails.append(f"invalid-token transition {NAME.get(frm,frm)} -> "
+                                     f"{NAME.get(to,to)} is not permitted by STANDARD.md")
+                # the whole point: reached INVALID_TOKEN, and DIRECTLY from disconnected
+                # (validation before the attempt), never via sending-request
+                eq("reached invalid-connect-token", INVALID_TOKEN in [t for _, t in imoves], True)
+                eq("invalid-token entered from disconnected (pre-attempt validation)",
+                   [f for f, t in imoves if t == INVALID_TOKEN], [DISCONNECTED])
+
     print(f"{checks} checks against STANDARD.md, {len(fails)} failures")
     print("  observed: " + " -> ".join([NAME.get(moves[0][0], "?")] + [NAME.get(t, "?") for _, t in moves]))
     for f in fails: print("  FAIL " + f)

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Check netcode/STANDARD.md's client state machine against the implementation.
+
+Drives a real client and server through a full connection lifecycle over UDP,
+records every client state transition, and checks the observed behaviour
+against the machine STANDARD.md specifies. Nothing here consults netcode.c;
+the states and legal transitions below are transcribed from the document.
+
+usage: python3 tools/conformance/verify_state_machine.py [--cc CC]
+exit:  0 = they agree, 1 = they do not, 2 = could not build/run
+"""
+import argparse, os, subprocess, sys, tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# STANDARD.md, "Client State Machine". Negative states are errors; 0 is the
+# initial state; 3 is the goal state.
+TOKEN_EXPIRED, INVALID_TOKEN, CONN_TIMEOUT = -6, -5, -4
+RESPONSE_TIMEOUT, REQUEST_TIMEOUT, DENIED = -3, -2, -1
+DISCONNECTED, SENDING_REQUEST, SENDING_RESPONSE, CONNECTED = 0, 1, 2, 3
+
+NAME = {TOKEN_EXPIRED: "connect token expired", INVALID_TOKEN: "invalid connect token",
+        CONN_TIMEOUT: "connection timed out", RESPONSE_TIMEOUT: "connection response timed out",
+        REQUEST_TIMEOUT: "connection request timed out", DENIED: "connection denied",
+        DISCONNECTED: "disconnected", SENDING_REQUEST: "sending connection request",
+        SENDING_RESPONSE: "sending challenge response", CONNECTED: "connected"}
+
+# Every transition STANDARD.md permits, with the sentence that licenses it.
+LEGAL = {
+    (DISCONNECTED, SENDING_REQUEST),      # "it transitions to sending connection request"
+    (DISCONNECTED, INVALID_TOKEN),        # token fails validation before the attempt
+    (SENDING_REQUEST, SENDING_RESPONSE),  # challenge packet received
+    (SENDING_REQUEST, DENIED),            # connection denied packet
+    (SENDING_REQUEST, REQUEST_TIMEOUT),   # neither challenge nor denied within timeout
+    (SENDING_RESPONSE, CONNECTED),        # keep-alive received
+    (SENDING_RESPONSE, DENIED),           # denied while sending challenge response
+    (SENDING_RESPONSE, RESPONSE_TIMEOUT), # neither keep-alive nor denied within timeout
+    (SENDING_RESPONSE, SENDING_REQUEST),  # retry against the next server address
+    (CONNECTED, DISCONNECTED),            # disconnect packet, or the client disconnecting
+    (CONNECTED, CONN_TIMEOUT),            # no payload or keep-alive within timeout
+}
+# "If the entire client connection process ... takes long enough that the connect
+# token expires" — reachable from any non-terminal state in the attempt.
+for s in (DISCONNECTED, SENDING_REQUEST, SENDING_RESPONSE):
+    LEGAL.add((s, TOKEN_EXPIRED))
+# A client may abandon an attempt at any point; the spec's disconnect path ends here.
+for s in (SENDING_REQUEST, SENDING_RESPONSE):
+    LEGAL.add((s, DISCONNECTED))
+
+
+def build_and_run(cc):
+    src = os.path.join(ROOT, "tools", "conformance", "drive_state_machine.c")
+    with tempfile.TemporaryDirectory() as tmp:
+        exe = os.path.join(tmp, "drive")
+        cmd = [cc, "-I" + ROOT, "-I" + os.path.join(ROOT, "sodium"), "-o", exe, src,
+               os.path.join(ROOT, "netcode.c"), os.path.join(ROOT, "sodium", "sodium.c")]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            print("build failed:\n" + r.stderr[:1500], file=sys.stderr); sys.exit(2)
+        r = subprocess.run([exe], capture_output=True, text=True, timeout=180)
+        if r.returncode != 0:
+            print("driver failed:\n" + (r.stdout + r.stderr)[:1500], file=sys.stderr); sys.exit(2)
+        return r.stdout
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cc", default=os.environ.get("CC", "cc"))
+    a = ap.parse_args()
+
+    transitions, result = [], None
+    for line in build_and_run(a.cc).splitlines():
+        f = line.split()
+        if f[0] == "STATE":   transitions.append((int(f[1]), int(f[2]), f[3]))
+        elif f[0] == "RESULT": result = f[1:]
+
+    checks, fails = 0, []
+    def eq(name, got, exp):
+        nonlocal checks; checks += 1
+        if got != exp: fails.append(f"{name}: got {got!r}, STANDARD.md says {exp!r}")
+
+    eq("driver completed the lifecycle", result and result[0], "ok")
+    eq("initial state is disconnected (0)", transitions[0][0], DISCONNECTED)
+
+    for frm, to, phase in transitions:
+        if frm == to: continue
+        checks += 1
+        if (frm, to) not in LEGAL:
+            fails.append(f"ILLEGAL transition '{NAME.get(frm,frm)}' -> '{NAME.get(to,to)}' "
+                         f"during '{phase}' is not permitted by STANDARD.md")
+
+    moves = [(f, t) for f, t, _ in transitions if f != t]
+
+    eq("happy path is disconnected -> sending request -> sending response -> connected -> disconnected",
+       moves, [(DISCONNECTED, SENDING_REQUEST), (SENDING_REQUEST, SENDING_RESPONSE),
+               (SENDING_RESPONSE, CONNECTED), (CONNECTED, DISCONNECTED)])
+
+    # "When the client receives a connection keep-alive packet ... transitions to connected"
+    # is the ONLY route in. Nothing may reach the goal state by another path.
+    for frm, to in moves:
+        if to == CONNECTED:
+            checks += 1
+            if frm != SENDING_RESPONSE:
+                fails.append(f"entered 'connected' from '{NAME.get(frm,frm)}'; STANDARD.md "
+                             "admits only 'sending challenge response'")
+
+    eq("no state change while connected and idle",
+       [p for f, t, p in transitions if f != t and p == "steady"], [])
+
+    # A clean disconnect is state 0, never an error state. The distinction is the
+    # difference between "the server said goodbye" and "something broke".
+    eq("clean disconnect ends in disconnected, not an error state",
+       moves[-1][1], DISCONNECTED)
+    checks += 1
+    if any(t < 0 for _, t in moves):
+        fails.append("an error state was reached during a clean lifecycle")
+
+    print(f"{checks} checks against STANDARD.md, {len(fails)} failures")
+    print("  observed: " + " -> ".join([NAME.get(moves[0][0], "?")] + [NAME.get(t, "?") for _, t in moves]))
+    for f in fails: print("  FAIL " + f)
+    if fails:
+        print("\nSTANDARD.md and the implementation disagree. One of them is wrong.")
+        return 1
+    print("\nSTANDARD.md's client state machine matches the implementation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/conformance/verify_state_machine.py
+++ b/tools/conformance/verify_state_machine.py
@@ -115,6 +115,54 @@ def main():
     if any(t < 0 for _, t in moves):
         fails.append("an error state was reached during a clean lifecycle")
 
+    # ---- error path: the transitions the happy path never exercises.
+    # STANDARD.md lists six error states; the happy-path driver reaches none of
+    # them, so the legal transitions into them were transcribed but untested.
+    # This provokes the connection-request timeout deterministically (a token
+    # pointed at an address where nothing listens) and checks the machine takes
+    # the licensed failure path rather than some other route.
+    err_src = os.path.join(ROOT, "tools", "conformance", "drive_error_paths.c")
+    # No silent skip: this driver is committed beside the checker, so its
+    # absence is a fault, not a reason to quietly check less. (The floors-test
+    # lesson: `if exists` around an assertion lets a rename disable a check
+    # while the suite stays green.)
+    checks += 1
+    if not os.path.exists(err_src):
+        fails.append("drive_error_paths.c is missing — the error-path phase cannot run")
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = os.path.join(tmp, "err")
+            r = subprocess.run([a.cc, "-I" + ROOT, "-I" + os.path.join(ROOT, "sodium"),
+                                "-o", exe, err_src, os.path.join(ROOT, "netcode.c"),
+                                os.path.join(ROOT, "sodium", "sodium.c")],
+                               capture_output=True, text=True)
+            if r.returncode != 0:
+                fails.append("error-path driver failed to build")
+            else:
+                out = subprocess.run([exe], capture_output=True, text=True, timeout=120).stdout
+                emoves, eresult = [], None
+                for line in out.splitlines():
+                    f = line.split()
+                    if f[0] == "STATE" and int(f[1]) != int(f[2]):
+                        emoves.append((int(f[1]), int(f[2])))
+                    elif f[0] == "RESULT":
+                        eresult = f[1:]
+                eq("error path reached an error state", eresult and eresult[0], "ok")
+                for frm, to in emoves:
+                    checks += 1
+                    if (frm, to) not in LEGAL:
+                        fails.append(f"error-path transition '{NAME.get(frm,frm)}' -> "
+                                     f"'{NAME.get(to,to)}' is not permitted by STANDARD.md")
+                # the request-timeout must be reached FROM sending-request, never
+                # from disconnected or by skipping the request stage
+                to_timeout = [f for f, t in emoves if t == REQUEST_TIMEOUT]
+                if REQUEST_TIMEOUT in [t for _, t in emoves]:
+                    eq("request-timeout entered from sending-request",
+                       to_timeout, [SENDING_REQUEST])
+                else:
+                    fails.append("expected CONNECTION_REQUEST_TIMED_OUT, reached "
+                                 + str([NAME.get(t,t) for _,t in emoves]))
+
     print(f"{checks} checks against STANDARD.md, {len(fails)} failures")
     print("  observed: " + " -> ".join([NAME.get(moves[0][0], "?")] + [NAME.get(t, "?") for _, t in moves]))
     for f in fails: print("  FAIL " + f)


### PR DESCRIPTION
`STANDARD.md` is the public protocol specification and the Go and Rust ports are written against it. Until now nothing checked it against `netcode.c`. A drifted spec is worse than no spec, because independent implementations are built on it and the failure is silent.

**tools/conformance** — 54 checks, the first verification this specification has ever had. Covers the 2048-byte connect token (every public field, both address forms, the zero padding), the packet prefix byte, the variable-length sequence encoding across every byte-count boundary including that the count is *minimal*, and the challenge token layout.

`STANDARD.md` itself is unchanged — it was already correct.

Deliberately out of scope, and stated in the README so a green run isn't mistaken for full coverage: encrypted packet bodies (checking them would reimplement libsodium and test the crypto, not the spec) and the client/server state machines, which are behaviour over time rather than bytes on the wire.

No release accompanies this.