### PR TITLE
netcode 1.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(netcode VERSION 1.4.0 LANGUAGES C CXX)
+project(netcode VERSION 1.4.1 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/netcode.h
+++ b/netcode.h
@@ -31,10 +31,10 @@
 #ifndef NETCODE_H
 #define NETCODE_H
 
-#define NETCODE_VERSION_FULL    "1.4.0"
+#define NETCODE_VERSION_FULL    "1.4.1"
 #define NETCODE_VERSION_MAJOR   1
 #define NETCODE_VERSION_MINOR   4
-#define NETCODE_VERSION_PATCH   0
+#define NETCODE_VERSION_PATCH   1
 
 /*
     IMPORTANT: netcode is single-threaded by design and is not thread safe.


### PR DESCRIPTION
Version bump for the 1.4.1 release. CMakeLists.txt and netcode.h move together, as `release-check.yml` compares tag == CMakeLists == header on the tag build.

**PATCH, deliberately.** Nothing in `netcode.h` changed, no behaviour changed, and the wire format is untouched — `netcode.c` is byte-identical to v1.4.0. Semver applies to the public interface, and the public interface did not move.

What 1.4.1 ships:
- **STANDARD.md gains `Nonce Reuse and Server Restarts`** (#165) — scopes the nonce-uniqueness guarantee to a single server run, and adds two optional, wire-compatible restart mitigations. Purely additive, 26 lines, protocol version stays `NETCODE 1.02`. This is the user-visible part: an implementer must read it.
- Conformance tooling under `tools/` that checks STANDARD.md against the implementation in CI.

No security content. The last security fix (AEAD nonce reuse across restart, `dc21b70`) shipped in v1.4.0 and is unchanged here.