### PR TITLE
netcode 1.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(netcode VERSION 1.4.1 LANGUAGES C CXX)
+project(netcode VERSION 1.4.2 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/netcode.h
+++ b/netcode.h
@@ -31,10 +31,10 @@
 #ifndef NETCODE_H
 #define NETCODE_H
 
-#define NETCODE_VERSION_FULL    "1.4.1"
+#define NETCODE_VERSION_FULL    "1.4.2"
 #define NETCODE_VERSION_MAJOR   1
 #define NETCODE_VERSION_MINOR   4
-#define NETCODE_VERSION_PATCH   1
+#define NETCODE_VERSION_PATCH   2
 
 /*
     IMPORTANT: netcode is single-threaded by design and is not thread safe.


### PR DESCRIPTION
Version bump for 1.4.2. CMakeLists.txt and netcode.h move together for `release-check.yml`.

**PATCH.** No API change, no behaviour change, no wire change — the vendored crypto's observable output is byte-identical to 1.4.1, verified by differential test.

Ships the libsodium 1.0.21/1.0.22 hardenings (#167):
- **`ACQUIRE_FENCE`** in all three AEAD decrypt paths — plaintext is not produced before authentication completes.
- **`crypto_verify_n` constant-time hardening** — the function that compares the Poly1305 tag, now defended against the compiler optimising it into something branchy.
- **poly1305 SSE2** optblocker in the final reduction.

Plus `test_crypto_aead_vectors`, a known-answer test that netcode did not previously have despite `sodium/NOTES.md` prescribing it as the primary validation.