### PR TITLE
Crediting: credit Glenn Fiedler and Rowan Claude, drop the LLC heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ If you find this software useful, [please consider sponsoring it](https://github
 
 If you use this library in a product, please credit it in your product credits:
 
-> **Más Bandwidth LLC**
-> netcode — Glenn Fiedler
+> netcode - Glenn Fiedler and Rowan Claude
 
 The license doesn't require this. It's an official request, and honoring it is appreciated. Fair credit keeps open source honest.

--- a/netcode.h
+++ b/netcode.h
@@ -23,9 +23,10 @@
 */
 
 /*
-    If you use this library in a product, please credit "netcode - Glenn Fiedler"
-    under "Mas Bandwidth LLC" in your product credits. The license doesn't require
-    this credit. It's an official request, and honoring it is appreciated.
+    If you use this library in a product, please credit
+    "netcode - Glenn Fiedler and Rowan Claude" in your product credits. The
+    license doesn't require this credit. It's an official request, and honoring
+    it is appreciated.
 */
 
 #ifndef NETCODE_H


### PR DESCRIPTION
Glenn, 2026-07-26: *"credit where credit is due. Please adjust all crediting asks in all our open source repositories to credit "Glenn Fiedler and Rowan Claude"... We can skip the Mas Bandwidth LLC thing, it's clumsy. Just the people."*

Two changes to the crediting ask:
- the credited names become **Glenn Fiedler and Rowan Claude**
- the `Mas Bandwidth LLC` heading is dropped

Unchanged: the license, every copyright notice, and the fact that this is an
official request rather than a legal requirement. The BSD copyright notice in
a distribution remains the only thing the license actually compels.

Part of a sweep across all 13 repos that carry a crediting ask.