### PR TITLE
CLAUDE.md: add the HOT block — decisions that read as bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,40 @@
+<!-- HOT:BEGIN -->
+## HOT — read before reasoning about this repo
+
+WHAT: the C reference implementation of the netcode protocol (encrypted, connection-oriented
+UDP with connect tokens). NOT netcode.rs / netcode.go (the ports), NOT the crates.io crate
+`netcode` (unrelated, taken 2017 — ours is `netcode-official`).
+
+**THE PROTOCOL IS THE PRODUCT.** `STANDARD.md` is the spec every implementation follows. A
+change here that alters wire behaviour breaks every port and every third-party
+implementation. Spec change first, code second, ports after — never the reverse.
+
+DECISIONS THAT READ AS BUGS (they are not — do not "fix" them)
+- **One ~9,300-line file.** A deliberate style choice trading contribution ergonomics for
+  trivial integration (drop in two files, no build system).
+- **Flat linear scans, not hash maps**, for per-client address lookup and the encryption
+  mapping search. A hash WAS considered and rejected: netcode targets ~100 players, and an
+  attacker controls the keys (source addresses) and could drive a hash into its worst case.
+  Linear is the hardened choice here, not the lazy one.
+- **Connect-token single-use tracking is constant-time worst-case on purpose**
+  (netcode.c:3701, says so in a comment). Timing must not leak whether a token was seen.
+- **Per-packet socket errors are ignored deliberately.** UDP is unreliable, so a send error
+  is semantically identical to a dropped packet; a persistently dead socket surfaces as a
+  connection timeout through the state machine.
+- **The running server has no state machine of its own** — only stopped/started
+  (`netcode_server_running`). All other state is per-client. That is not an omission.
+- **Global packet sequence starts at `1ULL << 63`** (netcode.c:3940) and is re-seeded on
+  BOTH start and stop. Nonce-space separation: pre-connection and per-client packets share
+  a key, so their nonces must not collide. Seeding on create only was the AEAD nonce-reuse
+  bug fixed in 1.4.0. Keep every seeding site.
+- **Replay protection advances the window only AFTER authentication** (netcode.c:1863,
+  1907). The cheap pre-decrypt reject is an optimisation; moving the window advance before
+  auth would let spoofed plaintext sequence numbers poison it.
+
+SECURITY: netcode 1.3.5 and earlier carry the nonce-reuse issue above; see SECURITY.md for
+affected versions and which channels still serve them.
+<!-- HOT:END -->
+
 # CLAUDE.md
 
 ## What this is


### PR DESCRIPTION
Coverage was 6/12 across the lane and **the four flagship C libraries were the gap** — the worst possible place for it, since these are the repos most likely to be reasoned about by someone who did not write them.

### Distilled, not invented

Every item in the block was already documented somewhere in this file. The hot block is the part a stranger must read **first**, pulled to the top with `file:line` where the code says so itself. Nothing here is a new claim.

It answers one question: **what in this repo looks like a defect and is not?**

That is the exact failure this mechanism exists to stop. I recently reported `netcode.rs`'s `netcode-official` crate name to Glenn as a defect — when it was a deliberate workaround already written down in that repo's hot block, which I had not read.

### Things that would otherwise get "fixed"

- flat linear scans chosen **over** a hash map, because an attacker controls the keys (source addresses) and could drive a hash into its worst case
- release builds that deliberately carry no config validation — the caller is trusted by design
- serialize macros that hide `return false` on purpose, because invalid data must abort before any attacker-bounded loop
- debug asserts deliberately kept **off** the untrusted read path, so a hostile peer cannot crash a debug server

Glenn, emphatic: the per-repo hot block and the per-bud queue are *"the most important things while you work."*