### PR TITLE
netcode 1.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(netcode VERSION 1.4.2 LANGUAGES C CXX)
+project(netcode VERSION 1.4.3 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/netcode.h
+++ b/netcode.h
@@ -32,10 +32,10 @@
 #ifndef NETCODE_H
 #define NETCODE_H
 
-#define NETCODE_VERSION_FULL    "1.4.2"
+#define NETCODE_VERSION_FULL    "1.4.3"
 #define NETCODE_VERSION_MAJOR   1
 #define NETCODE_VERSION_MINOR   4
-#define NETCODE_VERSION_PATCH   2
+#define NETCODE_VERSION_PATCH   3
 
 /*
     IMPORTANT: netcode is single-threaded by design and is not thread safe.


### PR DESCRIPTION
Patch release for #173 — `netcode_generate_connect_token` now bounds `num_server_addresses` at runtime instead of relying on asserts that `-DNDEBUG` removes.

Caller-controlled, not reachable from the wire. Cannot break a valid caller: anyone passing an out-of-range count was already in undefined behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)