### PR TITLE
SECURITY.md: link the published advisory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ affects every implementation of netcode rather than one.
 
 ## Known issue: nonce reuse between global and per-client packets (fixed in 1.4.0)
 
+**Advisory: [GHSA-3x95-24j9-7448](https://github.com/mas-bandwidth/netcode/security/advisories/GHSA-3x95-24j9-7448)** (published 2026-07-26; a CVE has been requested and is pending assignment).
+
 **Affected: netcode 1.3.5 and earlier. Fixed in 1.4.0.**
 
 Global packets (connection challenge, connection denied) encrypt with the same


### PR DESCRIPTION
[GHSA-3x95-24j9-7448](https://github.com/mas-bandwidth/netcode/security/advisories/GHSA-3x95-24j9-7448) was published today for the nonce-reuse issue this section already described.

Linking it because an advisory that can't be found from the repo is half-wasted — `SECURITY.md` is where someone checking this library actually looks, and the advisory page is not somewhere you land by accident.

CVE requested; the ID gets added here when GitHub's CNA assigns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)