### PR TITLE
Build strict: -ffp-contract=off replaces -ffast-math on every target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,6 +38,23 @@ By default netcode builds as a static library against the vendored libsodium sub
 - `BUILD_SHARED_LIBS=ON` builds `libnetcode` as a shared library.
 - `cmake --install` installs `netcode.h` and the library (`NETCODE_INSTALL=OFF` disables the install target, e.g. when embedding netcode as a subproject).
 
+## Floating point: netcode builds with -ffp-contract=off
+
+Estate policy for mas-bandwidth network libraries: builds are strict about floating point
+contraction. This build sets the right flag on every target, so nothing is required of you to
+build netcode itself:
+
+  - GCC/Clang: `-ffp-contract=off`. Not merely the absence of `-ffast-math` — GCC's default
+    is `-ffp-contract=fast`, which contracts across statement boundaries, and clang's default
+    `=on` still fuses within a single expression.
+  - MSVC: `/fp:precise`.
+
+netcode's wire format carries no floating point, so no flag is required of consumers for
+correct wire bytes today. The strict build is the family floor: contraction is
+architecture-dependent (FMA is in the aarch64 baseline and absent from the x86-64 one), so
+float arithmetic near a wire diverges bit-wise between architectures without it. If you
+compile `netcode.c` into your own build rather than linking the library, carry the same flag.
+
 ## Sanitizers and fuzzing
 
 To build everything with AddressSanitizer and UndefinedBehaviorSanitizer, configure with `-DNETCODE_SANITIZE=ON` and run the tests as usual:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,23 @@ add_compile_definitions(
     $<$<NOT:$<CONFIG:Debug>>:NETCODE_RELEASE>
 )
 
+# strict floating point. Estate policy for mas-bandwidth network libraries: "generally
+# speaking, network libraries we work on require -ffp-contract=off" (Glenn, 2026-08-24).
+#   - GCC/Clang: -ffp-contract=off. Not merely "no -ffast-math" -- GCC's default is
+#     -ffp-contract=fast, which contracts across statements, and clang's default =on still
+#     fuses within a single expression.
+#   - MSVC: /fp:precise, which since VS 2022 does not imply contraction.
+# netcode's wire format carries no floating point -- the floats here are connection stats
+# and the network simulator -- so this is the family floor rather than a wire fix:
+# contraction is architecture-dependent (FMA is in the aarch64 baseline and absent from
+# the x86-64 one), so any float arithmetic that ever nears the wire diverges bit-wise
+# between architectures without it. CI builds through this file, so every CI leg builds
+# with these flags.
 if(MSVC)
-    add_compile_options(/fp:fast)
+    add_compile_options(/fp:precise)
     set(NETCODE_WARNINGS /W4)
 else()
-    add_compile_options(-ffast-math)
+    add_compile_options(-ffp-contract=off)
     set(NETCODE_WARNINGS -Wall -Wextra)
 endif()
 


### PR DESCRIPTION
Enacts Glenn's standing estate policy (2026-08-24): *"generally speaking, network libraries we work on require -ffp-contract=off."* serialize sets and documents the flag; yojimbo came under the policy in mas-bandwidth/yojimbo#333. This brings netcode under it.

CMakeLists.txt replaces the global `-ffast-math` (GCC/Clang) and `/fp:fast` (MSVC) with `-ffp-contract=off` and `/fp:precise`. Global `add_compile_options`, so every target — library, sodium, examples, tests, fuzzers — builds strict, and since CI drives every leg through this file, CI now enforces the flag on all platforms. BUILDING.md gains a floating point section mirroring yojimbo's, stating the flags and the consumer requirement.

Honesty about scope: netcode's wire format carries no floating point — the floats in netcode.c are connection stats and the network simulator. So this is the policy's floor, not a wire fix; nothing measured wrong here today, and the docs say exactly that rather than claiming a mechanism this repo does not have. The floor exists because FMA is in the aarch64 baseline and absent from the x86-64 one, so any float arithmetic that ever nears the wire diverges bit-wise between architectures unless the family builds strict.

The fast-math flags date from the premake era; serialize made the same replacement (its docs call `-ffast-math` "the gate binaries' former flags"), and on MSVC there is no fast-minus-contraction spelling at all, so strict-replaces-fast is the only shape consistent across compilers.

Verified on this bench (arm64 mac, AppleClang, Release): build green, unit tests pass, `-ffp-contract=off` confirmed on the actual compile lines of `netcode.c` and `test.cpp` via `cmake --build --verbose`, zero remaining `ffast-math` occurrences in the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)