### PR TITLE
netcode 1.4.4: the header and CMake carry the new version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(netcode VERSION 1.4.3 LANGUAGES C CXX)
+project(netcode VERSION 1.4.4 LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/netcode.h
+++ b/netcode.h
@@ -32,10 +32,10 @@
 #ifndef NETCODE_H
 #define NETCODE_H
 
-#define NETCODE_VERSION_FULL    "1.4.3"
+#define NETCODE_VERSION_FULL    "1.4.4"
 #define NETCODE_VERSION_MAJOR   1
 #define NETCODE_VERSION_MINOR   4
-#define NETCODE_VERSION_PATCH   3
+#define NETCODE_VERSION_PATCH   4
 
 /*
     IMPORTANT: netcode is single-threaded by design and is not thread safe.


### PR DESCRIPTION
Version bump for the 1.4.4 release: strict floating-point builds (-ffp-contract=off / /fp:precise) on every target, and SECURITY.md links the published advisory.