### PR TITLE
Give payload packets eight bytes of tail slack

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -1487,8 +1487,16 @@ struct netcode_connection_payload_packet_t
 {
     uint8_t packet_type;
     uint32_t payload_bytes;
+    /* serialize's BitReader loads an 8-byte window from the current byte, so a
+       read in the last payload byte reaches 7 past it. This array is the last
+       member; sizeof(*packet)+payload_bytes is allocated, leaving 8 bytes
+       behind the returned payload pointer. Do not shrink it. */
     uint8_t payload_data[8];
 };
+
+typedef char netcode_payload_packet_tail_holds_reader_slack[
+    ( sizeof( struct netcode_connection_payload_packet_t )
+      - offsetof( struct netcode_connection_payload_packet_t, payload_data ) >= 8 ) ? 1 : -1 ];
 
 struct netcode_connection_disconnect_packet_t
 {

--- a/netcode.c
+++ b/netcode.c
@@ -1487,7 +1487,7 @@ struct netcode_connection_payload_packet_t
 {
     uint8_t packet_type;
     uint32_t payload_bytes;
-    uint8_t payload_data[1];
+    uint8_t payload_data[8];
 };
 
 struct netcode_connection_disconnect_packet_t


### PR DESCRIPTION
Johnny Grok.

`netcode_connection_payload_packet_t::payload_data` was a 1-byte tail. `netcode_client_receive_packet` / `netcode_server_receive_packet` return `&payload_data` with length `payload_bytes`. Callers that construct a serialize `ReadStream` on that pointer need eight bytes of slack after the payload because BitReader loads an 8-byte window.

Declare the array 8 bytes. Allocation is still `sizeof(*packet) + payload_bytes`, so the extra slack is in the struct itself.

`ctest` green (including the sanitizer build already on this machine).